### PR TITLE
Blockstates: Add Lex' remarks and fix the enumeration

### DIFF
--- a/blockstates/forgeBlockstates.md
+++ b/blockstates/forgeBlockstates.md
@@ -1,9 +1,9 @@
-Forges Blockstates
+Forge's Blockstates
 ===================
 
 Forge has its own blockstate json format to accommodate for modders needs. It introduces submodels, which allows you to build the final blockstate from different parts. You can build a models *normal* blockstate from multiple parts as well as create a complex variant depending on the blocks properties.
 
-*DISCLAIMER: Note that all models and textures referenced are from vanilla minecraft. For your own mod, you have to use the full location! For example: "mymod:blocks/blockTexture". You don't have to use Forges blockstate format at all, you can also use the vanilla format!*
+*DISCLAIMER: Note that all models and textures referenced are from vanilla minecraft. For your own mod, you have to use the full location! For example: "mymod:blocks/blockTexture". You don't have to use Forge's blockstate format at all, you can also use the vanilla format!*
 
 ## General structure of the format
 
@@ -44,7 +44,7 @@ The 1 is the version of the format, which ensures that old blockstate jsons can 
 	}
 ```
 
-The defaults section contains the default values for all variants. They can be overwritten by the variants. The defaults section is **optional**! You do not need to define defaults, the block can be omitted alltogether.
+The defaults section contains the default values for all variants. They can be overwritten by the variants. The defaults section is **optional**! You do not need to define defaults, the block can be omitted altogether.
 
 ```json
 	"variants": {
@@ -126,7 +126,7 @@ Instead of defining "this combination of properties gives model X" we say "this 
 
 * If mossy is true, the pressure plate uses the mossy cobblestone texture
 * If pillarCount is 1 it will add one wall with connection facing north. The default texture for the wall is oak-planks.
-* If pillarCount is 2 it will add two walls, both facing north. However the second wall will be rotated by 90 degree. This showcases that you do not need separate model with forges system. You only need once and rotate it around the Y axis. Additionally the texture of the walls is changed to cobblestone.
+* If pillarCount is 2 it will add two walls, both facing north. However the second wall will be rotated by 90 degree. This showcases that you do not need separate model with Forge's system. You only need once and rotate it around the Y axis. Additionally the texture of the walls is changed to cobblestone.
 * If pillarCount is 0 no walls will be added.
 
 And here is the result of our work:

--- a/blockstates/forgeBlockstates.md
+++ b/blockstates/forgeBlockstates.md
@@ -3,7 +3,7 @@ Forges Blockstates
 
 Forge has its own blockstate json format to accommodate for modders needs. It introduces submodels, which allows you to build the final blockstate from different parts. You can build a models *normal* blockstate from multiple parts as well as create a complex variant depending on the blocks properties.
 
-*DISCLAIMER: Note that all models and textures referenced are from vanilla minecraft. For your own mod, you have to use the full location! For example: "mymod:blocks/blockTexture"*
+*DISCLAIMER: Note that all models and textures referenced are from vanilla minecraft. For your own mod, you have to use the full location! For example: "mymod:blocks/blockTexture". You don't have to use Forges blockstate format at all, you can also use the vanilla format!*
 
 ## General structure of the format
 
@@ -44,7 +44,7 @@ The 1 is the version of the format, which ensures that old blockstate jsons can 
 	}
 ```
 
-The defaults section contains the default values for all variants. They can be overwritten by the variants.
+The defaults section contains the default values for all variants. They can be overwritten by the variants. The defaults section is **optional**! You do not need to define defaults, the block can be omitted alltogether.
 
 ```json
 	"variants": {
@@ -123,6 +123,7 @@ The model will be a pressure plate, and depending on its state it will have part
 The comments already explain the details on the separate parts, but here's how it works overall: The block definition in code has two Properties. One boolean property named "mossy" and one integer property named "pillarCount". Notice here that the string used in the json is **lowercase**, however. It has to be lowercase or it wont be found.
 
 Instead of defining "this combination of properties gives model X" we say "this value for this property has THAT impact on the model". In this example it's quite straight forward:
+
 * If mossy is true, the pressure plate uses the mossy cobblestone texture
 * If pillarCount is 1 it will add one wall with connection facing north. The default texture for the wall is oak-planks.
 * If pillarCount is 2 it will add two walls, both facing north. However the second wall will be rotated by 90 degree. This showcases that you do not need separate model with forges system. You only need once and rotate it around the Y axis. Additionally the texture of the walls is changed to cobblestone.

--- a/blockstates/introduction.md
+++ b/blockstates/introduction.md
@@ -25,4 +25,4 @@ The log only has one property: axis. A blockstate always has to be defined for a
 "east=false,north=false,south=false,west=false": { "model": "oak_fence_post" }
 ```
 And that is only one variant of 16. This can quickly lead to very big and verbose blockstate files, and is one of the main problems in Minecraft 1.8. Minecraft 1.9 will introduce a system that allows to get this under control. [Forges Blockstate Json][forge] allows you to do so in 1.8.
-[forge]: forgeBlockstates.md "Forges Blockstate Json"
+[forge]: forgeBlockstates.md "Forge's Blockstate Json"


### PR DESCRIPTION
I don't have a local setup to test if the enumeration is actually fixed, if you please would, tterrag. Weirdly enough it worked fine in the online editor I tested it with.

For documentation purposes: The issue is that the enumeration is interpreted as *foo* and therefore converted into multiple italic parts. If this doesn't fix it, then the line-endings are probably incorrect.