### PR TITLE
Fix admonition CSS

### DIFF
--- a/docs/css/code_fixer.css
+++ b/docs/css/code_fixer.css
@@ -1,7 +1,13 @@
 div.admonition code {
+  display: inline-block;
+  overflow-x: visible;
   color: #404040;
   border: 1px solid rgba(0, 0, 0, 0.2);
   background: rgba(255, 255, 255, 0.7);
+}
+
+div.admonition p {
+  margin-bottom: 5px;
 }
 
 p {

--- a/docs/css/code_fixer.css
+++ b/docs/css/code_fixer.css
@@ -1,6 +1,7 @@
 div.admonition code {
   display: inline-block;
   overflow-x: visible;
+  line-height: 18px;
   color: #404040;
   border: 1px solid rgba(0, 0, 0, 0.2);
   background: rgba(255, 255, 255, 0.7);
@@ -10,7 +11,7 @@ div.admonition p {
   margin-bottom: 5px;
 }
 
-p {
+p, ol, ul {
   text-align: justify;
 }
 


### PR DESCRIPTION
In addition to support for multiline code blocks in admonitions, the blocks also have a padding now. This should have actually always been the case, the padding wasn't applied due to the 'code' tags being inline elements, though. Last but not least, paragraphs within an admonition have a smaller bottom margin, making the entire design a little more compact.