### PR TITLE
Document registry system

### DIFF
--- a/docs/blocks/blocks.md
+++ b/docs/blocks/blocks.md
@@ -12,7 +12,7 @@ For simple blocks, which need no special functionality (think cobblestone, wood 
 
 - `setHardness` - Controls the time it takes to break the block. It is an arbitrary value. For reference, stone has a hardness of 1.5, and dirt 0.5. If the block should be unbreakable, a convenience method `setBlockUnbreakable` is provided.
 - `setResistance` - Controls the explosion resistance of the block. This is separate from hardness, but `setHardness` will also set the resistance to 5 times the hardness value, if the resistance is any lower than this value.
-- `setSoundType` - Controls the sound the block makes when it is punched, broken, or placed. Requires a `SoundType` argument, see the [sounds] page for more details.
+- `setSoundType` - Controls the sound the block makes when it is punched, broken, or placed. Requires a `SoundType` argument, see the [sounds][] page for more details.
 - `setLightLevel` - Controls the light emission of the block. **Note:** This method takes a value from zero to one, not zero to fifteen. To calculate this value, take the light level you wish your block to emit and divide by 16. For instance a block which emits level 5 light should pass `5 / 16f` to this method.
 - `setLightOpacity` - Controls the amount light passing through this block will be dimmed. Unlike `setLightLevel` this value is on a scale from zero to 15. For example, setting this to `3` will lower light by 3 levels every time it passes through this type of block.
 - `setUnlocalizedName` - Mostly self explanatory, sets the unlocalized name of the block. This name will be prepended with "tile." and appended with ".name" for localization purposes. For instance `setUnlocalizedName("foo")` will cause the block's actual localization key to be "tile.foo.name". For more advanced localization control, a custom Item will be needed. We'll get into this more later.
@@ -27,26 +27,19 @@ Of course, the above only allows for extremely basic blocks. If you want to add 
 Registering a Block
 -------------------
 
-So now that you have this block you've created, it's time to actually put it in the game. Thankfully this is extremely simple to do.
-
-As with most things, blocks can be registered using `GameRegistry.register(...)`. For this method your block must have a "registry name" which is just another way of saying "unique name". The preferred method to set your block's registry name is by calling `setRegistryName` on it inside the call to `register`. For instance, `GameRegistry.register(myBlock.setRegistryName("foo"))`.
+Blocks must be [registered][registering] to function.
 
 !!! important
-
-    There is a very large difference between a block in the world and a block in your inventory. A block in the world is governed by an instance of `Block`, it has a blockstate, a 4-bit meta, and maybe a tile entity. Meanwhile, an item in your inventory is controlled by an instance of `Item`, with a 16-bit damage/meta, and maybe an NBT tag. As a bridge between the different worlds of `Block` and `Item`, we have the class `ItemBlock`. `ItemBlock` is a subclass of `Item` that has a field `block` that holds a reference to the `Block` it represents. `ItemBlock` defines some of the behavior of a "block" as an item, like how a right click places the block. It's possible to have a `Block` without an `ItemBlock`. (E.g. `minecraft:water` is a block, but not an item.)
     
-    When you register a block, you *only* register a block. The block does not automatically have an `ItemBlock`. In order to give your block an `ItemBlock`, you should construct an `ItemBlock` from it and register that as well. The simplest way to do this like this: `GameRegistry.register(new ItemBlock(myBlock).setRegistryName(myBlock.getRegistryName()))`.
+    A block in the world and a "block" in an inventory are very different entities. A block in the world is represented by an `IBlockState`, and its behavior defined by an instance of `Block`. Meanwhile, an item in an inventory is an `ItemStack`, controlled by an `Item`. As a bridge between the different worlds of `Block` and `Item`, there exists the class `ItemBlock`. `ItemBlock` is a subclass of `Item` that has a field `block` that holds a reference to the `Block` it represents. `ItemBlock` defines some of the behavior of a "block" as an item, like how a right click places the block. It's possible to have a `Block` without an `ItemBlock`. (E.g. `minecraft:water` exists a block, but not an item. It is therefore impossible to hold it in an inventory as one.)
 
-!!! note
-
-    When using a simple string, the currently active mod's ID will be added. So if I was doing this from "mymod", the real registry name would be "mymod:foo".
-
-It is also possible to pass a `ResourceLocation` directly into `register`, but this is just convenience for calling `setRegistryName` with the `ResourceLocation` beforehand.
+    When a block is registered, *only* a block is registered. The block does not automatically have an `ItemBlock`. To create a basic `ItemBlock` for a block one should use `new ItemBlock(block).setRegistryName(block.getRegistryName())`. The unlocalized name is the same as the block's. Custom subclasses of `ItemBlock` may be used as well. Once an `ItemBlock` has been registered for a block, `Item.getItemFromBlock` can be used to retrieve it.
 
 Further Reading
 ---------------
 
-For information about block properties, such as those used for vanilla blocks like wood types, fences, walls, and many more, see the section on [blockstates].
+For information about block properties, such as those used for vanilla blocks like wood types, fences, walls, and many more, see the section on [blockstates][].
 
 [sounds]: ../effects/sounds.md
+[registering]: ../concepts/registries.md#registering-things
 [blockstates]: ../blockstates/states.md

--- a/docs/concepts/registries.md
+++ b/docs/concepts/registries.md
@@ -1,0 +1,84 @@
+Registries
+==========
+
+Registration is the process of taking the objects of a mod (items, blocks, sounds, etc.) and making them known to the game. Registering things is important, as without registration the game will simply not know about these objects in a mod and will exhibit great amounts of unexplainable behavior (and probably crash).
+
+Most things that require registration in the game are handled by the Forge registries. A registry is a simple object similar to a map that assigns values to keys. Additionally, they automatically assign integer IDs to values. Forge uses registries with `ResourceLocation` keys to register objects, which are of type `IForgeRegistryEntry`. This allows the RL to act like a "registry name" for the object. The registry name for an object may be accessed with `get`/`setRegistryName`. The setter can only ever be called once, and calling it twice results in an exception. Every type of registrable object has its own registry, and names in two different registries will not collide. (E.g. there's a registry for `Block`s, and a registry for `Item`s, and a `Block` and an `Item` may be registered with the same name `mod:example` without colliding. However, if two blocks were registered with that name, an exception would be thrown.) The default implementation of `IForgeRegistryEntry` (`IForgeRegistryEntry.Impl`) also provides two convenience implementations of `setRegistryName`: one where the parameter is a single string, and one where there are two string parameters. The overload that takes a single string checks whether the input contains a `:` (i.e. it checks whether the passed in stringified `ResourceLocation` has a domain), and if it doesn't it uses the current modid as the resource domain. The two argument overload simply constructs the registry name using the `modID` as the domain and `name` as the path.
+
+There also exists the "registry registry", a registry that registers other registries. This registry registers registries with `ResourceLocation` names and secondary `Class` keys. This allows one to look up the registry that registers a certain class (e.g. one can look up `Block.class` in the registry registry with `GameRegistry.findRegistry` to get the registry that registers blocks).
+
+Registering Things
+------------------
+
+The recommended way to register things is through the `RegistryEvent`s. In `RegistryEvent.NewRegistry`, registries should be created. Later, `RegistryEvent.Register` is fired once for each registered registry. Because `Register` is a generic event, the event handler should set the type parameter to the type of the object being registered. The event will contain the registry to register things to (`getRegistry`), and things may be registered with `register`(`All`) on the registry. Here's an example of an event handler that registers blocks:
+
+```java
+@SubscribeEvent
+public void registerBlocks(RegistryEvent.Register<Block> event) {
+    event.getRegistry().registerAll(block1, block2, ...);
+}
+```
+
+The order in which `RegistryEvent.Register` events fire is arbitrary, with the exception that `Block` will *always* fire first, and `Item` will *always* fire second, right after `Block`. After the `Register<Block>` event has fired, all [`ObjectHolder`][ObjectHolder] annotations are refreshed, and after `Register<Item>` has fired they are refreshed again. They are refreshed for a third time after *all* of the other `Register` events have fired.
+
+!!! important
+    These events are fired *before* preinit. This means that `@Mod.EventBusSubscriber` (or `MinecraftForge.EVENT_BUS.register` in the `@Mod` class's constructor for e.g. Scala mods which do not support `static`) should be used to register the event handler before preinit.
+
+There is another, older way of registering objects into registries, using `GameRegistry.register`. Anytime something suggests using this method, it should be replaced with an event handler for the appropriate registry event. This method simply finds the registry corresponding to an `IForgeRegistryEntry` with `IForgeRegistryEntry::getRegistryType`, and then registers the object to the registry. There is also a convenience overload that takes an `IForgeRegistryEntry` (`ifre`) and an RL, which is equivalent to `GameRegistry.register(ifre.setRegistryName(rl))`.
+
+Creating Registries
+-------------------
+
+Registries are not only for Forge. Any mod can create their own registries, and any mod can register things to registries from any other mod. Registries are created by using `RegistryBuilder`. This class takes certain parameters for the registry it will generate, such as the name. the `Class` of it's values, and various callbacks for when the registry is changed. Upon calling `RegistryBuilder::create`, the registry is built, registered to the registry registry, and returned to the caller.
+
+Injecting Registry Values Into Fields
+-------------------------------------
+
+It is possible to have Forge inject values from registries into `public static final` fields of classes. This is done by annotating classes and fields with `@ObjectHolder`. If a class has this annotation, all the `public static final` fields within are taken to be object holders too, and the value of the annotation is the domain of the holder (i.e. every field uses it as the default domain for the registry name of the object to inject). If a field has this annotation, and the value does not contain a domain, the domain is chosen from the surrounding class's `@ObjectHolder` annotation. If the class is not annotated in this situation, the field is ignored with a warning. If it does contain a domain, then the object to inject into the field is the object with that name. If the class has the annotation and one of the `public static final` fields does not, then the resource path of the object's name is taken to be the field's name. The type of the registry is taken from the type of the field.
+
+!!! note
+    If an object is not found, either because the object itself hasn't been registered or because the registry does not exist, a debug message is logged and the field is left unchanged.
+
+As these rules are rather complicated, here are some examples:
+
+```java
+@ObjectHolder("minecraft") // Resource domain "minecraft"
+class AnnotatedHolder {
+    public static final Block diamond_block = null; // public static final is required.
+                                                    // Type Block means that the Block registry will be queried.
+                                                    // diamond_block is the field name, and as the field is not annotated it is taken to be the resource path.
+                                                    // As there is no explicit domain, "minecraft" is inherited from the class.
+                                                    // Object to be injected: "minecraft:diamond_block" from the Block registry.
+
+    @ObjectHolder("ender_eye")
+    public static final Item eye_of_ender = null;   // Type Item means that the Item registry will be queried.
+                                                    // As the annotation has the value "ender_eye", that overrides the field's name.
+                                                    // As the domain is not explicit, "minecraft" is inherited from the class.
+                                                    // Object to be injected: "minecraft:ender_eye" from the Item registry.
+
+    @ObjectHolder("neomagicae:coffeinum")
+    public static final ManaType coffeinum = null;  // Type ManaType means that the ManaType registry will be queried. This is obviously a registry made by a mod.
+                                                    // As the annotation has the value "neomagicae:coffeinum", that overrides the field's name.
+                                                    // The domain is explicit, and is "neomagicae", overriding the class's "minecraft" default.
+                                                    // Object to be injected: "neomagicae:coffeinum" from the ManaType registry.
+
+    public static final Item ENDER_PEARL = null;    // Note that the actual name is "minecraft:ender_pearl", not "minecraft:ENDER_PEARL".
+                                                    // Therefore, THIS WILL FAIL. The field has to be lowercased or annotated.
+}
+
+class UnannotatedHolder { // Note lack of annotation on this class.
+    @ObjectHolder("minecraft:flame")
+    public static final Enchantment flame = null;   // No annotation on the class means that there is no preset domain to inherit.
+                                                    // Field annotation supplies all the information for the object.
+                                                    // Object to be injected: "minecraft:flame" from the Enchantment registry.
+
+    public static final Biome ice_flat = null;      // No annotation on the class or the field.
+                                                    // Therefore this just gets ignored.
+
+    @ObjectHolder("levitation")
+    public static final Potion levitation = null;   // No resource domain in annotation, and no default specified by class annotation.
+                                                    // Therefore, THIS WILL FAIL. The field annotation needs a domain, or the class needs an annotation.
+}
+```
+
+[ObjectHolder]: #injecting-registry-values-into-fields

--- a/docs/effects/sounds.md
+++ b/docs/effects/sounds.md
@@ -1,47 +1,34 @@
 Sounds
 ======
 
-!!!Note
-    This guide was written at a time when the latest Forge build was build 1907 for Minecraft 1.9.0. It should be valid for any Forge version that has the new Forge registry system.
-
-Goals
------
-
-  * Describe a simple way to implement sounds in Forge
-  * There are many, many versions of `playSound` in Minecraft. Describe what they all do
-
 Terminology
 -----------
 
 | Term | Description |
-|-|-|
-| Sound Events | Something that triggers a sound effect. Examples include `"minecraft:block.anvil.hit"` or `"botania:spreaderFire"`. |
+|----------------|----------------|
+|  Sound Events  | Something that triggers a sound effect. Examples include `"minecraft:block.anvil.hit"` or `"botania:spreaderFire"`. |
 | Sound Category | The category of the sound, for example `"player"`, `"block"` or simply `"master"`. The sliders in the sound settings GUI represent these categories. |
-| Sound File | The literal file on disk that is played, usually an .ogg file. |
+|   Sound File   | The literal file on disk that is played, usually an .ogg file. |
 
-Sounds.json
------------
+`sounds.json`
+-------------
 
-This json should be located in your base asset directory:
-```
-src/main/resources/assets/[mod id]/sounds.json
-```
-This indicates to the vanilla resource system what Sound Events you declare and what Sound Files those events use.
+This json should be located in the `assets` directory of a mod: `src/main/resources/assets/<modid>/sounds.json`. This file declares sound events and identifies which sound files they use.
 
-A full specification is available on the vanilla [wiki], but we highlight the important parts here with an example:
+A full specification is available on the vanilla [wiki][], but this example highlights the important parts:
 
-```Json
+```json
 {
-  "openChest": {
+  "open_chest": {
     "category": "block",
     "subtitle": "mymod.subtitle.openChest",
-    "sounds": [ "mymod:openChestSoundFile" ]
+    "sounds": [ "mymod:open_chest_sound_file" ]
   },
-  "epicMusic": {
+  "epic_music": {
     "category": "record",
     "sounds": [
       {
-        "name": "mymod:music/epicMusic",
+        "name": "mymod:music/epic_music",
         "stream": true
       }
     ]
@@ -49,30 +36,28 @@ A full specification is available on the vanilla [wiki], but we highlight the im
 }
 ```
 
-Underneath the top-level object, each key we have defined corresponds to a Sound Event we want to tell the game about: `"mymod:openChest"` and `"mymod:epicMusic"`. Note that they are written in the sounds.json without the modid.
+!!! important
+    Like the rest of the resource system, everything_should_be_in_snake_case.
 
-Under each event we specify the category of the Sound Event, then a subtitle localization key to be shown to hard of hearing users when the Sound Event is played. 
+Underneath the top-level object, each key corresponds to a sound event. Note that they are written in the sounds.json without the modid. Each event specifies its category, and a localization key to be shown when subtitles are enabled. Finally, the actual sound files to be played are specified. Note that the value is an array; if multiple sound files are specified then the game will randomly choose one to play whenever the sound event is triggered.
 
-Finally, we specify the actual Sound Files to be played. Note that the value is an array - if we specify multiple Sound Files then the game will randomly choose one to play whenever the Sound Event is triggered.
+The two examples represent two different ways to specify a sound file. The [wiki][] has precise details, but generally, long sound files such as BGM or music discs should use the second form, because the "stream" argument tells Minecraft to not load the entire sound file into memory but instead to stream it from disk. The second form can also specify the volume, pitch, and random weight of that sound file.
 
-The two examples represent two different ways to specify a Sound File. The [wiki] has precise details, but generally, make sure to use the second form for long Sound Files such as BGM or music discs, because the "stream" argument tells Minecraft to not load the entire Sound File into memory but instead stream it from disk. Using the second form also allows you to specify the volume, pitch, and random weight of that Sound File - again, see the vanilla [wiki] for precise details.
+In all cases, the path to a sound file for domain `domain` and path `path` is `assets/<domain>/sounds/<path>.ogg`. Therefore `mymod:open_chest_sound_file` points to `assets/mymod/sounds/open_chest_sound_file.ogg`, and `mymod:music/epic_music` points to `assets/mymod/sounds/music/epic_music.ogg`.
 
-In either case, you specify the path to your Sound File starting from your "sounds" asset directory.  
-Thus, `"mymod:openChestSoundFile"` corresponds to the path `assets/mymod/sounds/openChestSoundFile.ogg`
-and `"mymod:music/epicMusic"` corresponds to the path `assets/mymod/sounds/music/epicMusic.ogg`.
+Creating Sound Events
+---------------------
 
-Code Registration
------------------
+In order to actually be able to play sounds, a `SoundEvent` corresponding to an entry in `sounds.json` must be created. This `SoundEvent` must then be [registered][registration]. Normally, the location used to create a sound event should be set as it's registry name.
 
-Simply specifying the Sound Events in JSON isn't enough, however. Due to changes in the sound system in 1.9, we must also register Sound Events in code. This very simple to do: 
+Creating a `SoundEvent`:
 
-```Java
-ResourceLocation location = new ResourceLocation("mymod", "openChest");
+```java
+ResourceLocation location = new ResourceLocation("mymod", "open_chest");
 SoundEvent event = new SoundEvent(location);
-GameRegistry.register(event, location);
 ```
 
-Hold on to the `SoundEvent` object as you'll need it later to play sounds. If you have an API and want addons to be able to play your Sound Events, then put these in your API (Do not register them in your API, just have fields in your API that you set during initialization of the actual mod).
+The `SoundEvent` acts as a reference to the sound, and is passed around to actually play sounds. Therefore, the `SoundEvent` should be stored somewhere. If a mod has an API, it should expose its `SoundEvent`s in the API.
 
 Playing Sounds
 --------------
@@ -82,49 +67,53 @@ Vanilla has lots of methods for playing sounds, and it's unclear which to use at
 !!! Note
     This information was gathered by looking at these various methods, analyzing their usage and categorizing them accordingly. It is up-to-date as of Forge 1907, please let someone know if it is out of date!
 
-Note that each takes a `SoundEvent`, the ones that you registered above. Also be aware that the terms *"Server Behavior"* and *"Client Behavior"* refer to the respective **logical** side. For more information on this differentiation, see [this article](../concepts/sides.md).
+Note that each takes a `SoundEvent`, the ones registered above. Additionally, the terms *"Server Behavior"* and *"Client Behavior"* refer to the respective [**logical** side][sides].
 
 ### `World`
 
-  1. <a name="world-playsound-pbecvp"></a>`playSound(EntityPlayer, BlockPos, SoundEvent, SoundCategory, volume, pitch)`
-      - Simply forwards to [overload (2)](#world-playsound-pxyzecvp), adding 0.5 to each coordinate of the `BlockPos` given
-  2. <a name="world-playsound-pxyzecvp"></a>`playSound(EntityPlayer, double x, double y, double z, SoundEvent, SoundCategory, volume, pitch)`
-      - **Client Behavior**: If the passed in player is *the* client player, plays the  Sound Event to the client player
-      - **Server Behavior**: Plays the Sound Event to everyone nearby **except** the passed in player. Player can be `null`.
-      - **Usage**: The correspondence between the behaviors implies that these two methods are to be called from some player-initiated code that will be run on both logical sides at the same time - the logical client handles playing it to the user and the logical server handles everyone else hearing it without re-playing it to the original user.<br>
-                   They can also be used to play any sound in general at any position server-side by calling it on the logical server and passing in a `null` player, thus letting everyone hear it.
-  3. <a name="world-playsound-xyzecvpd"></a>`playSound(double x, double y, double z, SoundEvent, SoundCategory, volume, pitch, distanceDelay)`
-      - **Client Behavior**: Just plays the Sound Event in the client world. If `distanceDelay` is `true`, then delays the sound based on how far it is from the player.
-      - **Server Behavior**: Does nothing.
-      - **Usage**: This method only works client-side, and thus is useful for sounds that you send in custom packets, or other client-only effect-type sounds. Used for thunder.
+1. <a name="world-playsound-pbecvp"></a> `playSound(EntityPlayer, BlockPos, SoundEvent, SoundCategory, volume, pitch)`
+    - Simply forwards to [overload (2)](#world-playsound-pxyzecvp), adding 0.5 to each coordinate of the `BlockPos` given.
+
+2. <a name="world-playsound-pxyzecvp"></a> `playSound(EntityPlayer, double x, double y, double z, SoundEvent, SoundCategory, volume, pitch)`
+    - **Client Behavior**: If the passed in player is *the* client player, plays the sound event to the client player.
+    - **Server Behavior**: Plays the sound event to everyone nearby **except** the passed in player. Player can be `null`.
+    - **Usage**: The correspondence between the behaviors implies that these two methods are to be called from some player-initiated code that will be run on both logical sides at the same time - the logical client handles playing it to the user and the logical server handles everyone else hearing it without re-playing it to the original user.
+       They can also be used to play any sound in general at any position server-side by calling it on the logical server and passing in a `null` player, thus letting everyone hear it.
+
+3. <a name="world-playsound-xyzecvpd"></a> `playSound(double x, double y, double z, SoundEvent, SoundCategory, volume, pitch, distanceDelay)`
+    - **Client Behavior**: Just plays the sound event in the client world. If `distanceDelay` is `true`, then delays the sound based on how far it is from the player.
+    - **Server Behavior**: Does nothing.
+    - **Usage**: This method only works client-side, and thus is useful for sounds sent in custom packets, or other client-only effect-type sounds. Used for thunder.
 
 ### `WorldClient`
 
-  1. <a name="worldclient-playsound-becvpd"></a>`playSound(BlockPos, SoundEvent, SoundCategory, volume, pitch, distanceDelay)`
-      - Simply forwards to `World`'s [overload (3)](#world-playsound-xyzecvpd), adding 0.5 to each coordinate of the `BlockPos` given.
+1. <a name="worldclient-playsound-becvpd"></a> `playSound(BlockPos, SoundEvent, SoundCategory, volume, pitch, distanceDelay)`
+    - Simply forwards to `World`'s [overload (3)](#world-playsound-xyzecvpd), adding 0.5 to each coordinate of the `BlockPos` given.
 
 ### `Entity`
 
-  1. <a name="entity-playsound-evp"></a>`playSound(SoundEvent, volume, pitch)`
-      - Forwards to `World`'s [overload (2)](#world-playsound-pxyzecvp), passing in `null` as the player.
-      - **Client Behavior**: Does nothing.
-      - **Server Behavior**: Plays the Sound Event to everyone at this entity's position.
-      - **Usage**: Emitting any sound from any non-player entity server-side.
+1. <a name="entity-playsound-evp"></a> `playSound(SoundEvent, volume, pitch)`
+    - Forwards to `World`'s [overload (2)](#world-playsound-pxyzecvp), passing in `null` as the player.
+    - **Client Behavior**: Does nothing.
+    - **Server Behavior**: Plays the sound event to everyone at this entity's position.
+    - **Usage**: Emitting any sound from any non-player entity server-side.
 
 ### `EntityPlayer`
 
-  1. <a name="entityplayer-playsound-evp"></a>`playSound(SoundEvent, volume, pitch)` (overriding the one in [`Entity`](#entity-playsound-evp))
-      - Forwards to `World`'s [overload (2)](#world-playsound-pxyzecvp), passing in `this` as the player
-      - **Client Behavior**: Does nothing, see override in [`EntityPlayerSP`](#entityplayersp-playsound-evp).
-      - **Server Behavior**: Plays the sound to everyone nearby *except* this player.
-      - **Usage**: See [`EntityPlayerSP`]().
+1. <a name="entityplayer-playsound-evp"></a> `playSound(SoundEvent, volume, pitch)` (overriding the one in [`Entity`](#entity-playsound-evp))
+    - Forwards to `World`'s [overload (2)](#world-playsound-pxyzecvp), passing in `this` as the player.
+    - **Client Behavior**: Does nothing, see override in [`EntityPlayerSP`](#entityplayersp-playsound-evp).
+    - **Server Behavior**: Plays the sound to everyone nearby *except* this player.
+    - **Usage**: See [`EntityPlayerSP`](#entityplayersp-playsound-evp).
 
 ### `EntityPlayerSP`
 
-  1. <a name="entityplayersp-playsound-evp"></a>`playSound(SoundEvent, volume, pitch)` (overriding the one in [`EntityPlayer`](#entityplayer-playsound-evp))
-    - Forwards to `World`'s [overload (2)](#world-playsound-pxyzecvp), passing in `this` as the player
+1. <a name="entityplayersp-playsound-evp"></a> `playSound(SoundEvent, volume, pitch)` (overriding the one in [`EntityPlayer`](#entityplayer-playsound-evp))
+    - Forwards to `World`'s [overload (2)](#world-playsound-pxyzecvp), passing in `this` as the player.
     - **Client Behavior**: Just plays the Sound Event.
     - **Server Behavior**: Method is client-only.
     - **Usage**: Just like the ones in `World`, these two overrides in the player classes seem to be for code that runs together on both sides. The client handles playing the sound to the user, while the server handles everyone else hearing it without re-playing to the original user.
 
 [wiki]: http://minecraft.gamepedia.com/Sounds.json
+[registration]: ../concepts/registries.md#registering-things
+[sides]: ../concepts/sides.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ pages:
     - Forge Update Checker: 'gettingstarted/autoupdate.md'
   - Concepts:
     - Sides: 'concepts/sides.md'
+    - Registries: 'concepts/registries.md'
   - Blocks:
     - Home: 'blocks/blocks.md'
     - Interaction: 'blocks/interaction.md'


### PR DESCRIPTION
Document what registries are, what they do, how to create them, and how to register objects to them. Also document the new registry events as the preferred method of registering objects.

Update other pages to refer to the new page when referring to registration.
