### PR TITLE
Update capabilities.md

### DIFF
--- a/docs/datastorage/capabilities.md
+++ b/docs/datastorage/capabilities.md
@@ -10,7 +10,7 @@ Forge adds capability support to TileEntities, Entities, and ItemStacks, which c
 Forge-provided Capabilities
 ---------------------------
 
-As of this writing, Forge provides three capabilities: IItemHandler, IFluidHandler and IEnergyStorage
+Forge provides three capabilities: IItemHandler, IFluidHandler and IEnergyStorage
 
 IItemHandler exposes an interface for handling inventory slots. It can be applied to TileEntities (chests, machines, etc.), Entities (extra player slots, mob/creature inventories/bags), or ItemStacks (portable backpacks and such). It replaces the old `IInventory` and `ISidedInventory` with an automation-friendly system.
 
@@ -79,7 +79,7 @@ As mentioned, attaching capabilities to entities and itemstacks can be done usin
 * `AttachCapabilityEvent<Item>`: Fires only for item stacks.
 * `AttachCapabilityEvent<World>`: Fires only for worlds.
 
-The generic type can not be more specific than the above, meaning that if you want to attach capabilities to an object of a certain subclass, say `EntityPlayer`, you have to subscribe to `AttachCapabilityEvent<Entity>`, then determine if the object is an `EntityPlayer` and attach the capability respectively.
+The generic type cannot be more specific than the specified above types. For example: If you want to attach capabilities to `EntityPlayer`, you have to subscribe to the `AttachCapabilityEvent<Entity>`, and then determine that the provided object is an `EntityPlayer` before attaching the capability.
 
 In all cases, the event has a method `addCapability`, which can be used to attach capabilities to the target object. Instead of adding capabilities themselves to the list, you add capability providers, which have the chance to return capabilities only from certain sides. While the provider only needs to implement `ICapabilityProvider`, if the capability needs to store data persistently it is possible to implement `ICapabilitySerializable<T extends NBTBase>` which, on top of returning the capabilities, will allow providing NBT save/load functions.
 

--- a/docs/datastorage/capabilities.md
+++ b/docs/datastorage/capabilities.md
@@ -79,7 +79,7 @@ As mentioned, attaching capabilities to entities and itemstacks can be done usin
 * `AttachCapabilityEvent<Item>`: Fires only for item stacks.
 * `AttachCapabilityEvent<World>`: Fires only for worlds.
 
-The generic type cannot be more specific than the specified above types. For example: If you want to attach capabilities to `EntityPlayer`, you have to subscribe to the `AttachCapabilityEvent<Entity>`, and then determine that the provided object is an `EntityPlayer` before attaching the capability.
+The generic type cannot be more specific than the above types. For example: If you want to attach capabilities to `EntityPlayer`, you have to subscribe to the `AttachCapabilityEvent<Entity>`, and then determine that the provided object is an `EntityPlayer` before attaching the capability.
 
 In all cases, the event has a method `addCapability`, which can be used to attach capabilities to the target object. Instead of adding capabilities themselves to the list, you add capability providers, which have the chance to return capabilities only from certain sides. While the provider only needs to implement `ICapabilityProvider`, if the capability needs to store data persistently it is possible to implement `ICapabilitySerializable<T extends NBTBase>` which, on top of returning the capabilities, will allow providing NBT save/load functions.
 


### PR DESCRIPTION
This has two changes:
1. It removes `As of this writing, ` because it should instead just be kept up to date. Surely Forge isn't going to be adding new ones every day, so it shouldn't be too difficult to keep it updated.
2. It makes the explanation of the generic type to `AttachCapabilityEvent` much less confusing by splitting it up into different sentences.