### PR TITLE
Add classpath fix note for IDEA 2016 to terminal steps, too

### DIFF
--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -19,6 +19,7 @@ From Zero to Modding
 6. Load your project into your IDE.
     * For Eclipse, create a workspace anywhere (though the easiest location is one level above your project folder). Then simply import your project folder as a project, everything will be done automatically.
     * For IntelliJ, you only need to create run configs. You can run `gradlew genIntellijRuns` to do this.
+    * **Note:** If you are using IDEA 2016 or newer, you will have to fix the classpath module. Go to `Edit configurations` and in both `Minecraft Client` and `Minecraft Server`, change `Use classpath of module` to point to the task with a name like `<project>_main`.
 
 !!! note
 

--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -39,13 +39,15 @@ From Zero to Modding
 Terminal-free IntelliJ IDEA configuration
 ------------------------------------------
 
-These instructions assume that you have created the project folder as described in the steps 1 to 3 of the section above. Because of that, the numbering starts at 4.
+These instructions assume that you have created the project folder as described in the **steps 1 to 3 of the section above**. Because of that, the numbering starts at 4.
 
-4. Launch IDEA and choose to open/import the `build.gradle` file, using the default gradle wrapper choice. While you wait for this process to finish, you can open the gradle panel, which will get filled with the gradle tasks once importing is completed.
-5. Run the `setupDecompWorkspace` task (inside the `forgegradle` task group). It will take a few minutes, and use quite a bit of RAM. If it fails, you can add `-Xmx3G` to the `Gradle VM options` in IDEA's gradle settings window, or edit your global gradle properties.
-6. Once the setup task is done, you will want to run the `genIntellijRuns` task, which will configure the project's run/debug targets. 
-7. After it's done, you should click the blue refresh icon **on the gradle panel** (there's another refresh icon on the main toolbar, but that's not it). This will re-synchronize the IDEA project with the Gradle data, making sure that all the dependencies and settings are up to date.
-8. Finally, assuming you use IDEA 2016 or newer, you will have to fix the classpath module. Go to `Edit configurations` and in both `Minecraft Client` and `Minecraft Server`, change `Use classpath of module` to point to the task with a name like `<project>_main`.
+<ol start="4">
+  <li>Launch IDEA and choose to open/import the `build.gradle` file, using the default gradle wrapper choice. While you wait for this process to finish, you can open the gradle panel, which will get filled with the gradle tasks once importing is completed.</li>
+  <li>Run the `setupDecompWorkspace` task (inside the `forgegradle` task group). It will take a few minutes, and use quite a bit of RAM. If it fails, you can add `-Xmx3G` to the `Gradle VM options` in IDEA's gradle settings window, or edit your global gradle properties.</li>
+  <li>Once the setup task is done, you will want to run the `genIntellijRuns` task, which will configure the project's run/debug targets. </li>
+  <li>After it's done, you should click the blue refresh icon **on the gradle panel** (there's another refresh icon on the main toolbar, but that's not it). This will re-synchronize the IDEA project with the Gradle data, making sure that all the dependencies and settings are up to date.</li>
+  <li>Finally, assuming you use IDEA 2016 or newer, you will have to fix the classpath module. Go to `Edit configurations` and in both `Minecraft Client` and `Minecraft Server`, change `Use classpath of module` to point to the task with a name like `<project>_main`. </li>
+</ol>
 
 If all the steps worked correctly, you should now be able to choose the Minecraft run tasks from the dropdown, and then click the Run/Debug buttons to test your setup.
 


### PR DESCRIPTION
This note is only in the steps list for "Terminal-free IntelliJ IDEA configuration":

> 8. Finally, assuming you use IDEA 2016 or newer, you will have to fix the classpath module. Go to `Edit configurations` and in both `Minecraft Client` and `Minecraft Server`, change `Use classpath of module` to point to the task with a name like `<project>_main`.

It should be added to  the first list "From Zero to Modding", too.

In addition to that, I fixed the "Terminal-free configuration" list's indexing.