### PR TITLE
Documented available RegistryEvents

### DIFF
--- a/docs/concepts/registries.md
+++ b/docs/concepts/registries.md
@@ -23,6 +23,8 @@ public void registerBlocks(RegistryEvent.Register<Block> event) {
 
 The order in which `RegistryEvent.Register` events fire is arbitrary, with the exception that `Block` will *always* fire first, and `Item` will *always* fire second, right after `Block`. After the `Register<Block>` event has fired, all [`ObjectHolder`][ObjectHolder] annotations are refreshed, and after `Register<Item>` has fired they are refreshed again. They are refreshed for a third time after *all* of the other `Register` events have fired.
 
+`RegistryEvent`s are currently supported for the following types: `Block`, `Item`, `Potion`, `Biome`, `SoundEvent`, `PotionType`, `Enchantment`, `IRecipe`, `VillagerProfession`, `Entity`
+
 There is another, older way of registering objects into registries, using `GameRegistry.register`. Anytime something suggests using this method, it should be replaced with an event handler for the appropriate registry event. This method simply finds the registry corresponding to an `IForgeRegistryEntry` with `IForgeRegistryEntry::getRegistryType`, and then registers the object to the registry. There is also a convenience overload that takes an `IForgeRegistryEntry` and a `ResourceLocation`, which is equivalent to calling `IForgeRegistryEntry::setRegistryName`, followed by a `GameRegistry.register` call.
 
 Creating Registries

--- a/docs/concepts/registries.md
+++ b/docs/concepts/registries.md
@@ -23,7 +23,7 @@ public void registerBlocks(RegistryEvent.Register<Block> event) {
 
 The order in which `RegistryEvent.Register` events fire is arbitrary, with the exception that `Block` will *always* fire first, and `Item` will *always* fire second, right after `Block`. After the `Register<Block>` event has fired, all [`ObjectHolder`][ObjectHolder] annotations are refreshed, and after `Register<Item>` has fired they are refreshed again. They are refreshed for a third time after *all* of the other `Register` events have fired.
 
-`RegistryEvent`s are currently supported for the following types: `Block`, `Item`, `Potion`, `Biome`, `SoundEvent`, `PotionType`, `Enchantment`, `IRecipe`, `VillagerProfession`, `Entity`
+`RegistryEvent`s are currently supported for the following types: `Block`, `Item`, `Potion`, `Biome`, `SoundEvent`, `PotionType`, `Enchantment`, `IRecipe`, `VillagerProfession`, `EntityEntry`
 
 There is another, older way of registering objects into registries, using `GameRegistry.register`. Anytime something suggests using this method, it should be replaced with an event handler for the appropriate registry event. This method simply finds the registry corresponding to an `IForgeRegistryEntry` with `IForgeRegistryEntry::getRegistryType`, and then registers the object to the registry. There is also a convenience overload that takes an `IForgeRegistryEntry` and a `ResourceLocation`, which is equivalent to calling `IForgeRegistryEntry::setRegistryName`, followed by a `GameRegistry.register` call.
 

--- a/docs/conventions/loadstages.md
+++ b/docs/conventions/loadstages.md
@@ -12,7 +12,7 @@ Each of these stages occurs at a different point in the loading stage and thus w
 !!! important
 
     Many objects that were previously registered in loading stage event handlers (Blocks, Items, Recipes, etc.) should now be registered via [RegistryEvents][registering].
-    This is to pave the way to being able to reload mods dyanamically at runtime, which can't be done using loading stages (as they are fired once upon application startup).
+    This is to pave the way to being able to reload mods dynamically at runtime, which can't be done using loading stages (as they are fired once upon application startup).
     RegistryEvents are fired after Pre-Initialization.
 
 ## Pre-Initialization

--- a/docs/conventions/loadstages.md
+++ b/docs/conventions/loadstages.md
@@ -12,6 +12,8 @@ Each of these stages occurs at a different point in the loading stage and thus w
 !!! important
 
     Many objects that were previously registered in loading stage event handlers (Blocks, Items, Recipes, etc.) should now be registered via [RegistryEvents][registering].
+    This is to pave the way to being able to reload mods dyanamically at runtime, which can't be done using loading stages (as they are fired once upon application startup).
+    RegistryEvents are fired after Pre-Initialization.
 
 ## Pre-Initialization
 

--- a/docs/conventions/loadstages.md
+++ b/docs/conventions/loadstages.md
@@ -6,7 +6,12 @@ There are some other events that are important too, depending on what your mod d
 Each of these stages occurs at a different point in the loading stage and thus what can be safely done in each stage varies.
 
 !!! note
+
     Loading stage events can only be used in your `@Mod` class, in methods marked with the `@EventHandler` annotation.
+
+!!! important
+
+    Many objects that were previously registered in loading stage event handlers (Blocks, Items, Recipes, etc.) should now be registered via [RegistryEvents][registering].
 
 ## Pre-Initialization
 
@@ -42,3 +47,5 @@ Common actions to preform in postInit are:
 
   * IMCEvent: Process received IMC Messages
   * FMLServerStartingEvent: Register Commands
+
+[registering]: ../concepts/registries.md#registering-things


### PR DESCRIPTION
Given that it is now "recommended and HIGHLY encouraged" to use RegistryEvents over registering during loading events, I thought it might be helpful to list which objects can be registered using RegistryEvents. I also added a link to the Loading Stages page to encourage modders not to continue doing their registrations there. In response to #85, I also included a bit of information around why RegistryEvents should be preferred.

Not having an in-depth knowledge of the inner-workings or direction motivations of Forge itself, if anything I've added is incorrect I'm happy to make changes.