### PR TITLE
Correct example MessageHandler to use addScheduledTask(...)

### DIFF
--- a/docs/networking/simpleimpl.md
+++ b/docs/networking/simpleimpl.md
@@ -61,7 +61,13 @@ public class MyMessageHandler implements IMessageHandler<MyMessage, IMessage> {
     EntityPlayerMP serverPlayer = ctx.getServerHandler().playerEntity;
     // The value that was sent
     int amount = message.toSend;
-    serverPlayer.inventory.addItemStackToInventory(new ItemStack(Items.diamond, amount));
+    // Excecute the action on the main server thread by adding it as a scheduled task
+    serverPlayer.getServerWorld().addScheduledTask(new Runnable() {
+      @Override
+        public void run() {
+            serverPlayer.inventory.addItemStackToInventory(new ItemStack(Items.diamond, amount));
+        }
+    }
     // No response packet
     return null;
   }
@@ -74,10 +80,12 @@ It is recommended (but not required) that for organization's sake, this class is
 
     As of Minecraft 1.8 packets are by default handled on the network thread.
 
-    That means that your `IMessageHandler` can _not_ interact with most game objects directly. The example above for example would not be correct.
+    That means that your `IMessageHandler` can _not_ interact with most game objects directly. 
     Minecraft provides a convenient way to make your code execute on the main thread instead using `IThreadListener.addScheduledTask`.
+    
+    The way to obtain an `IThreadListener` is using either the `Minecraft` instance (client side) or a `WorldServer` instance (server side. The code above shows an example of this by getting a WorldServer instance from an EntityPlayerMP.
 
-    The way to obtain an `IThreadListener` is using either the `Minecraft` instance (client side) or a `WorldServer` instance (server side).
+    ).
 
 !!! warning
 

--- a/docs/networking/simpleimpl.md
+++ b/docs/networking/simpleimpl.md
@@ -65,9 +65,9 @@ public class MyMessageHandler implements IMessageHandler<MyMessage, IMessage> {
     serverPlayer.getServerWorld().addScheduledTask(new Runnable() {
       @Override
         public void run() {
-            serverPlayer.inventory.addItemStackToInventory(new ItemStack(Items.diamond, amount));
+            serverPlayer.inventory.addItemStackToInventory(new ItemStack(Items.DIAMOND, amount));
         }
-    }
+    });
     // No response packet
     return null;
   }

--- a/docs/networking/simpleimpl.md
+++ b/docs/networking/simpleimpl.md
@@ -83,7 +83,7 @@ It is recommended (but not required) that for organization's sake, this class is
     That means that your `IMessageHandler` can _not_ interact with most game objects directly. 
     Minecraft provides a convenient way to make your code execute on the main thread instead using `IThreadListener.addScheduledTask`.
     
-    The way to obtain an `IThreadListener` is using either the `Minecraft` instance (client side) or a `WorldServer` instance (server side). The code above shows an example of this by getting a WorldServer instance from an EntityPlayerMP.
+    The way to obtain an `IThreadListener` is using either the `Minecraft` instance (client side) or a `WorldServer` instance (server side). The code above shows an example of this by getting a `WorldServer` instance from an `EntityPlayerMP`.
 
 !!! warning
 

--- a/docs/networking/simpleimpl.md
+++ b/docs/networking/simpleimpl.md
@@ -83,9 +83,7 @@ It is recommended (but not required) that for organization's sake, this class is
     That means that your `IMessageHandler` can _not_ interact with most game objects directly. 
     Minecraft provides a convenient way to make your code execute on the main thread instead using `IThreadListener.addScheduledTask`.
     
-    The way to obtain an `IThreadListener` is using either the `Minecraft` instance (client side) or a `WorldServer` instance (server side. The code above shows an example of this by getting a WorldServer instance from an EntityPlayerMP.
-
-    ).
+    The way to obtain an `IThreadListener` is using either the `Minecraft` instance (client side) or a `WorldServer` instance (server side). The code above shows an example of this by getting a WorldServer instance from an EntityPlayerMP.
 
 !!! warning
 

--- a/docs/networking/simpleimpl.md
+++ b/docs/networking/simpleimpl.md
@@ -61,12 +61,9 @@ public class MyMessageHandler implements IMessageHandler<MyMessage, IMessage> {
     EntityPlayerMP serverPlayer = ctx.getServerHandler().playerEntity;
     // The value that was sent
     int amount = message.toSend;
-    // Excecute the action on the main server thread by adding it as a scheduled task
-    serverPlayer.getServerWorld().addScheduledTask(new Runnable() {
-      @Override
-        public void run() {
-            serverPlayer.inventory.addItemStackToInventory(new ItemStack(Items.DIAMOND, amount));
-        }
+    // Execute the action on the main server thread by adding it as a scheduled task
+    serverPlayer.getServerWorld().addScheduledTask(() -> {
+      serverPlayer.inventory.addItemStackToInventory(new ItemStack(Items.DIAMOND, amount));
     });
     // No response packet
     return null;


### PR DESCRIPTION
- Uses an anonymous implementation of `Runnable()` and adds it via `addScheduledTask()` to prevent threading errors
- Updates the warning block to indicate the changes
- Changes `Items.diamond` to its correct name, `Items.DIAMOND`

**Justification**: What is the point of doing something incorrectly just to correct it a few lines down? Docs should show only the correct implementations as examples.

**_Side question_**: Should the documentation use an anonymous `Runnable` implementing class (as is used with this PR) or with a _block lambda expression_? (**lines 65-70** would instead read as follows)

```java
serverPlayer.getServerWorld().addScheduledTask(() -> {
    serverPlayer.inventory.addItemStackToInventory(new ItemStack(Items.DIAMOND, amount));
});
```