### PR TITLE
added a note for pack_format: 3 and lowercase resource files

### DIFF
--- a/docs/conventions/locations.md
+++ b/docs/conventions/locations.md
@@ -19,6 +19,8 @@ Localizations are plain-text files with the file extension .lang and the name be
 
 They are located in the `./assets/<modid>/lang/` folder.
 
+Please note that if you use pack_format: 3 in src/main/resources/pack.mcmeta, all resources including language files should be lowercase (eg: en_us.lang)
+
 ### Models
 
 Model files are in JSON format and are located in `./assets/<modid>/models/block/` or `./assets/<modid>/models/item/` depending on whether they are for a block or an item, respectively.


### PR DESCRIPTION
Hey guys,

Just spent hours to find out why my translations from en_US.lang weren't working.
It seemed the documentation could be more clear here on the pack_format.

Kind regards,
TvL2386