### PR TITLE
Reduce confusion regarding gradle wrapper scripts

### DIFF
--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -9,8 +9,9 @@ From Zero to Modding
 1. Obtain a source distribution from forge's [files][] site. (Look for the Mdk file type, or Src in older 1.8/1.7 versions).
 2. Extract the downloaded source distribution to an empty directory. You should see a bunch of files, and an example mod is placed in `src/main/java` for you to look at. Only a few of these files are strictly necessary for mod development, and you may reuse these files for all your projects These files are:
     * `build.gradle`
-    * `gradlew` (both `.bat` and `.sh`)
-    * The `gradle` folder
+    * `gradlew.bat`
+    * `gradlew`
+    * the `gradle` folder
 3. Move the files listed above to a new folder, this will be your mod project folder.
 4. Open up a command prompt in the folder you created in step (3), then run `gradlew setupDecompWorkspace`. This will download a bunch of artifacts from the internet needed to decompile and build Minecraft and forge. This might take some time, as it will download stuff and then decompile Minecraft. Note that, in general, these things will only need to be downloaded and decompiled once, unless you delete the gradle artifact cache.
 5. Choose your IDE: Forge explicitly supports developing with Eclipse or IntelliJ environments, but any environment, from Netbeans to vi/emacs, can be made to work.


### PR DESCRIPTION
There is no `gradlew.sh`, at least not in the latest mdk (and AFAIK the gradle wrapper script for *nix never had a file extension), the files the docs refer to here are `gradlew.bat` (for Windows) and simply `gradlew` (for anybody else). I think it reduces friction for people unfamiliar with gradle to just explicitly spell out the names of both files and not mention a `.sh` file name extension that does not exist.