### PR TITLE
Add a note about lang file names with pack_format 3

### DIFF
--- a/docs/conventions/locations.md
+++ b/docs/conventions/locations.md
@@ -15,7 +15,11 @@ Blockstate definition files are in the JSON format and are in the `./assets/<mod
 
 ### Localizations
 
-Localizations are plain-text files with the file extension .lang and the name being their [language code](https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx) such as `en_US`.
+Localizations are plain-text files with the file extension `.lang` and the name being their [language code](https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx) such as `en_US`.
+
+!!! note
+
+    If a `pack_format` of 3 is specified in a `pack.mcmeta` file, the language code should be lowercase.
 
 They are located in the `./assets/<modid>/lang/` folder.
 


### PR DESCRIPTION
This'll do until 1.13 when we have to rewrite this for the new json format, anyways.

Solves #124, #137, and #148 