### PR TITLE
Add Dependency Management page

### DIFF
--- a/docs/gettingstarted/dependencymanagement.md
+++ b/docs/gettingstarted/dependencymanagement.md
@@ -1,0 +1,23 @@
+Dependency Management
+=====================
+
+Forge has some support for managing and loading mod dependencies. Libraries, and even other mods, can be embedded in builds in a way that lets Forge extract and load them at runtime in a compatible manner.
+
+The mod repository
+------------------
+
+The mod repository is a Maven-like repository containing mods and libraries. An artifact in this repository is identified by its Maven coordinate: `groupId:artifactId:version:classifier@extention`. Classifer and extension are optional. Forge can archive, manage and load mods and libraries in this repository. The mod repository may contain multiple versions of mods and libraries, including snapshot versions.
+
+Forge can archive a jar in the repository if its `Maven-Artifact` manifest attribute is defined. The value of this attribute should be its Maven coordinate.
+
+The mod repository supports snapshot artifacts. If the artifact version ends with `-SNAPSHOT`, the artifact will be resolved as the version with the latest timestamp. The timestamp can be set as the `Timestamp` manifest attribute, which should be the time since the epoch in milliseconds.
+
+
+Dependency extraction
+---------------------
+
+Forge provides a simple way to embed dependencies in a mod and have them extracted at runtime. By placing dependency jars in your own jar, Forge can extract them into the mod repository and load them. This can be used as an alternative to shading, and comes with the potential benefit of resolving dependency version conflicts.
+
+The contained dependencies of a jar file are marked by the `ContainedDeps` manifest attribute. Its value should be a space separated list of the names of contained jar files that will be extracted. These jar files should be placed in `/META-INF/libraries/{entry}`.
+
+Forge will inspect the manifest of the contained jar to determine its Maven coordinate so that it may be archived. If a file `/META-INF/libraries/{entry}.meta` exists, Forge will read this as the jar's manifest instead. The dependency will be archived in the local repository according to its `Maven-Artifact` manifest attribute.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ pages:
     - Home: 'gettingstarted/index.md'
     - Structuring Your Mod: 'gettingstarted/structuring.md'
     - Forge Update Checker: 'gettingstarted/autoupdate.md'
+    - Dependency Management: 'gettingstarted/dependencymanagement.md'
   - Concepts:
     - Sides: 'concepts/sides.md'
     - Resources: 'concepts/resources.md'


### PR DESCRIPTION
Based on what was introduced in this PR https://github.com/MinecraftForge/MinecraftForge/pull/4841. This is mostly about the dependency extraction part, but also adds a necessary introduction to repositories.

Requesting review from @LexManos on this one. A specific thing I could use feedback on is the name "The mod repository". That is what I have called the repository where contained dependencies are archived. Is there perhaps a better name? I also deliberately chose to not document the deprecated behavior, namely placing contained dependencies in the jar root and not specifying the Maven-Artifact manifest attribute.