### PR TITLE
Update Forge Theme for mkdocs v17

### DIFF
--- a/forge_theme/base.html
+++ b/forge_theme/base.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% if page_title %}{{ page_title }} - {% endif %}{{ site_name }}</title>
+    <title>{% block title_prefix %}{% endblock %}{% if not page.is_homepage %}{{ page.title }} - {% endif %}{{ config.site_name }}</title>
 
     <link rel="apple-touch-icon" sizes="180x180" href="http://www.minecraftforge.net/forum/uploads/set_resources_3/247441864ab051a2bd22c960e8e7b8b5_apple-touch-icon.png">
     <link rel="icon" type="image/png" href="http://www.minecraftforge.net/forum/uploads/set_resources_3/247441864ab051a2bd22c960e8e7b8b5_favicon-32x32.png" sizes="32x32">
@@ -24,12 +24,15 @@
     {% endfor %}
 
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-    <script type="text/javascript" src="https://use.fontawesome.com/a1f20be65b.js"></script>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/regular.css" integrity="sha384-EWu6DiBz01XlR6XGsVuabDMbDN6RT8cwNoY+3tIH+6pUCfaNldJYJQfQlbEIWLyA" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/fontawesome.css" integrity="sha384-GVa9GOgVQgOk+TNYXu7S/InPTfSDTtBalSgkgqQ7sCik56N9ztlkoTr2f/T44oKV" crossorigin="anonymous">
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery-mousewheel/3.1.13/jquery.mousewheel.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jScrollPane/2.0.23/script/jquery.jscrollpane.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/stickyfill/1.1.4/stickyfill.min.js"></script>
     <script type="text/javascript" src="{{ base_url }}/js/theme.js"></script>
+
+    <script>var base_url = '{{ base_url }}';</script>
     {% for path in extra_javascript %}
     <script src="{{ path }}"></script>
     {% endfor %}
@@ -51,9 +54,6 @@
         ga('send', 'pageview');
     </script>
     {% endif %}
-
-    {% block extrahead %}
-    {% endblock %}
 </head>
 <body>
 <header>
@@ -94,17 +94,17 @@
     <div class="sidebar-sticky-wrapper-content">
         <article class="docs-entry">
             {% block content %}
-            {{ content }}
+            {{ page.content }}
             {% endblock %}
         </article>
         {%- block next_prev %}
         {% if next_page or previous_page %}
         <div class="docs-entry-footer-buttons" role="navigation" aria-label="footer navigation">
             {% if previous_page %}
-            <a href="{{ previous_page.url }}" title="{{ previous_page.title }}" class="btn"><span class="fa fa-arrow-left"></span> Previous</a>
+            <a href="{{ page.previous_page.url }}" title="{{ page.previous_page.title }}" class="btn"><span class="fa fa-arrow-left"></span> Previous</a>
             {% endif %}
             {% if next_page %}
-            <a href="{{ next_page.url }}" title="{{ next_page.title }}" class="float-right btn">Next <span class="fa fa-arrow-right"></span></a>
+            <a href="{{ page.next_page.url }}" title="{{ page.next_page.title }}" class="float-right btn">Next <span class="fa fa-arrow-right"></span></a>
             {% endif %}
         </div>
         {% endif %}

--- a/forge_theme/nav.html
+++ b/forge_theme/nav.html
@@ -1,14 +1,14 @@
 {% if not nav_item.children %}
-<li {% if nav_item.active %}class="elem-active{% if toc %} elem-toc{% endif %}" {% endif %}>
+<li {% if nav_item.active %}class="elem-active{% if page.toc %} elem-toc{% endif %}" {% endif %}>
     {% if nav_item.active %}
-    <a href="{{ (toc|first).url }}" class="elem-text">{{ nav_item.title }}</a>
+    <a href="{{ (page.toc|first).url }}" class="elem-text">{{ nav_item.title }}</a>
     {% else %}
     <a href="{{ nav_item.url }}" class="elem-text">{{ nav_item.title }}</a>
     {% endif %}
     {% if nav_item.active %}
     <ul class="table-of-contents">
-        {% for toc_item in toc %}
-        {% if toc_item != (toc|first) %}
+        {% for toc_item in page.toc %}
+        {% if toc_item != (page.toc|first) %}
         <li class="toc-item"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
         {% endif %}
         {% for toc_item in toc_item.children %}
@@ -21,7 +21,7 @@
 {% else %}
 <li class="elem-parent">
     {% if nav_item.children.active %}
-    <a href="{{ (toc|first).url }}" class="elem-text">{{ nav_item.title }}</a>
+    <a href="{{ (page.toc|first).url }}" class="elem-text">{{ nav_item.title }}</a>
     {% else %}
     <a href="#" class="elem-text toggle-collapsible"><span class="fa fa-plus collapsible-icon"></span> {{ nav_item.title }}</a>
     {% endif %}

--- a/forge_theme/search.html
+++ b/forge_theme/search.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 
-{% block extrahead %}
-<script>var base_url = '{{ base_url }}';</script>
-<script data-main="{{ base_url }}/mkdocs/js/search.js" src="{{ base_url }}/mkdocs/js/require.js"></script>
-{% endblock %}
+{% block title_prefix %}Search Results{% endblock %}
 
 {% block search_form %}
 <form class="search" id="content_search" action="search.html">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,5 +79,9 @@ markdown_extensions:
   - toc:
       permalink: ' '
 
-theme: null
-theme_dir: 'forge_theme'
+theme:
+  name: null
+  custom_dir: forge_theme
+# Technically deprecated, but RTD overrides theme.custom_dir with their default style
+# They still seem to respect the old option, though
+theme_dir: forge_theme


### PR DESCRIPTION
This fixes #171. Read the Docs appears to have updated their build scripts to use mkdocs version 17.x at some point in the last few weeks. The new version introduced changes to theme building that needed to be addressed.

While testing out the new build, I'd also noticed the (admittedly weird) FontAwesome JS solution to not work reliably, so I also changed that to use CSS.

It looks like RTD heavily wants to push its default themes. They even override the `theme.custom_dir` option which is the correct way to define a theme directory in the new versions of mkdocs, while the old `theme_dir` is deprecated, yet still supported by RTD. If RTD updates to a version of mkdocs that removes `theme_dir`, chances are our custom theme won't work at all anymore.