### PR TITLE
Update links from HTTP to HTTPS where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Documentation
-This is the Read the docs MinecraftForge documentation, located at http://mcforge.readthedocs.org.
+This is the Read the docs MinecraftForge documentation, located at https://mcforge.readthedocs.org.
 
 It is intended to provide detailed documentation of Forge development. Javadocs will not be hosted here, however. They will be located at ...
 

--- a/docs/conventions/versioning.md
+++ b/docs/conventions/versioning.md
@@ -1,7 +1,7 @@
 Versioning
 ==========
 
-In general projects, [Semantic Versioning](http://semver.org/) is often used (which has the format `MAJOR.MINOR.PATCH`). However, in the case of modding it may be more beneficial to use the format `MCVERSION-MAJORMOD.MAJORAPI.MINOR.PATCH`, to be able to differentiate between world-breaking and API-breaking changes of a mod.
+In general projects, [Semantic Versioning](https://semver.org/) is often used (which has the format `MAJOR.MINOR.PATCH`). However, in the case of modding it may be more beneficial to use the format `MCVERSION-MAJORMOD.MAJORAPI.MINOR.PATCH`, to be able to differentiate between world-breaking and API-breaking changes of a mod.
 
 Examples
 --------

--- a/docs/effects/sounds.md
+++ b/docs/effects/sounds.md
@@ -111,7 +111,7 @@ Note that each takes a `SoundEvent`, the ones registered above. Additionally, th
     - **Server Behavior**: Method is client-only.
     - **Usage**: Just like the ones in `World`, these two overrides in the player classes seem to be for code that runs together on both sides. The client handles playing the sound to the user, while the server handles everyone else hearing it without re-playing to the original user.
 
-[wiki]: http://minecraft.gamepedia.com/Sounds.json
+[wiki]: https://minecraft.gamepedia.com/Sounds.json
 [registration]: ../concepts/registries.md#registering-things
 [ResourceLocation]: ../concepts/resources.md#resourcelocation
 [sides]: ../concepts/sides.md

--- a/docs/gettingstarted/autoupdate.md
+++ b/docs/gettingstarted/autoupdate.md
@@ -35,7 +35,7 @@ The JSON itself has a relatively simple format, given as follows:
 This is fairly self-explanatory, but some notes:
  
 * The link under `homepage` is the link the user will be shown when the mod is outdated.
-* Forge uses an internal algorithm to determine whether one version String of your mod is "newer" than another. Most versioning schemes should be compatible, but see the `ComparableVersion` class if you are concerned about whether your scheme is supported. Adherence to [semantic versioning](http://semver.org/) is highly recommended.
+* Forge uses an internal algorithm to determine whether one version String of your mod is "newer" than another. Most versioning schemes should be compatible, but see the `ComparableVersion` class if you are concerned about whether your scheme is supported. Adherence to [semantic versioning](https://semver.org/) is highly recommended.
 * The changelog string can be separated into lines using `\n`. Some prefer to include a abbreviated changelog, then link to an external site that provides a full listing of changes.
 * Manually inputting data can be chore. You can configure your `build.gradle` to automatically update this file when building a release, as Groovy has native JSON parsing support. Doing this is left as an exercise to the reader.
 

--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -34,7 +34,7 @@ From Zero to Modding
 
 
 [home directory]: https://en.wikipedia.org/wiki/Home_directory#Default_home_directory_per_operating_system "Default user's home folder location for different operation systems"
-[files]: http://files.minecraftforge.net "Forge Files distribution site"
+[files]: https://files.minecraftforge.net "Forge Files distribution site"
 
 Terminal-free IntelliJ IDEA configuration
 ------------------------------------------

--- a/docs/gettingstarted/structuring.md
+++ b/docs/gettingstarted/structuring.md
@@ -56,7 +56,7 @@ The default Gradle configuration replaces `${version}` with the project version,
 | dependencies | [string] |   `[]`   | A list of modids. All of the listed mods will load *before* this one. If one is not present, nothing happens. |
 |   dependants | [string] |   `[]`   | A list of modids. All of the listed mods will load *after* this one. If one is not present, nothing happens. |
 
-A good example `mcmod.info` that uses many of these properties is [BuildCraft](http://gist.github.com/anonymous/05ad9a1e0220bbdc25caed89ef0a22d2).
+A good example `mcmod.info` that uses many of these properties is [BuildCraft](https://gist.github.com/anonymous/05ad9a1e0220bbdc25caed89ef0a22d2).
 
 The Mod File
 ------------
@@ -91,7 +91,7 @@ Here is a table of the properties of `@Mod`:
 
 <a name="version-ranges" style="color: inherit; text-decoration: inherit">\* All version ranges use the [Maven Version Range Specification](https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html).</a>
 
-You can find an example mod in the [Forge src download](http://files.minecraftforge.net/).
+You can find an example mod in the [Forge src download](https://files.minecraftforge.net/).
 
 Keeping Your Code Clean Using Sub-packages
 ------------------------------------------

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,4 +8,4 @@ This documentation is _only_ for Forge, **this is not a Java tutorial**.
 Contribute to the docs at [GitHub].
 
 [MinecraftForge]: http://minecraftforge.net
-[GitHub]: http://github.com/MinecraftForge/Documentation
+[GitHub]: https://github.com/MinecraftForge/Documentation

--- a/docs/items/loot_tables.md
+++ b/docs/items/loot_tables.md
@@ -171,4 +171,4 @@ table.fillInventory(iinventory, world.rand, ctx);
 !!! Note
     This only works with `IInventory` for now.
 
-[wiki]: http://minecraft.gamepedia.com/Loot_table
+[wiki]: https://minecraft.gamepedia.com/Loot_table

--- a/docs/models/blockstates/introduction.md
+++ b/docs/models/blockstates/introduction.md
@@ -48,5 +48,5 @@ This is one case of 5. You can read this as "when east=true, use the model oak_f
 [blockstate]: ../../blocks/states.md
 [statemapper]: ../using.md#block-models
 [Forge blockstate]: forgeBlockstates.md
-[wiki]: http://minecraft.gamepedia.com/Model#Block_states
+[wiki]: https://minecraft.gamepedia.com/Model#Block_states
 [item blockstates]: ../using.md#blockstate-jsons-for-items

--- a/docs/models/color.md
+++ b/docs/models/color.md
@@ -17,4 +17,4 @@ If an item inherits from the `builtin/generated` model, each layer ("layer0", "l
 
 This registration must be done client-side, in the initialization phase.
 
-[wiki]: http://minecraft.gamepedia.com/Model#Block_models
+[wiki]: https://minecraft.gamepedia.com/Model#Block_models

--- a/docs/models/files.md
+++ b/docs/models/files.md
@@ -40,7 +40,7 @@ Blitz3D Models
 
 Forge adds a loader for the `.b3d` file format. To use these models, the resource domain must be registered through `B3DLoader.addDomain`. This loader accepts any model location that is in a registered domain and whose path ends in `.b3d`.
 
-[JSON model format]: http://minecraft.gamepedia.com/Model#Block_models
+[JSON model format]: https://minecraft.gamepedia.com/Model#Block_models
 [overrides]: overrides.md
 [blockstate JSON]: blockstates/introduction.md
 [UV]: https://en.wikipedia.org/wiki/UV_mapping

--- a/docs/models/overrides.md
+++ b/docs/models/overrides.md
@@ -49,4 +49,4 @@ item.addPropertyOverride(new IItemPropertyGetter() {
 }
 ```
 
-[format]: http://minecraft.gamepedia.com/Model#Item_models
+[format]: https://minecraft.gamepedia.com/Model#Item_models

--- a/docs/networking/index.md
+++ b/docs/networking/index.md
@@ -12,5 +12,5 @@ There are a variety of techniques provided by Forge to facilitate communication 
 The simplest, for a new mod, would be [SimpleImpl][], where most of the complexity of the netty system is
 abstracted away. It uses a message and handler style system.
 
-[netty]: http://netty.io "Netty website"
+[netty]: https://netty.io "Netty website"
 [SimpleImpl]: simpleimpl.md "SimpleImpl in detail"

--- a/forge_theme/base.html
+++ b/forge_theme/base.html
@@ -115,7 +115,7 @@
 </main>
 <div class="wrapper">
     <footer>
-        Built with <a href="http://www.mkdocs.org">MkDocs</a> using a custom theme. Hosted by <a href="https://readthedocs.org">Read the Docs</a>.
+        Built with <a href="https://www.mkdocs.org">MkDocs</a> using a custom theme. Hosted by <a href="https://readthedocs.org">Read the Docs</a>.
         <div class="theme-switch-wrapper">
             Enable Dark Theme
             <label class="theme-switch">


### PR DESCRIPTION
There were a bunch of links using HTTP to sites that supported HTTPS, so I changed all of them to use HTTPS. Of course, some sites only supported HTTP, so I did not change those.

I also fixed some trailing spaces… or rather, my editor fixed them, and then I noticed it while submitting this PR. So hooray for bonus fixes, I guess? :stuck_out_tongue: