### PR TITLE
Add 'static' to the lootLoad event listener method

### DIFF
--- a/docs/items/loot_tables.md
+++ b/docs/items/loot_tables.md
@@ -85,7 +85,7 @@ Next, an example of one of the most common use cases for modifying vanilla loot:
 First, listen for the event for the table we want to modify:
 ```Java
 @SubscribeEvent
-public void lootLoad(LootTableLoadEvent evt) {
+public static void lootLoad(LootTableLoadEvent evt) {
     if (evt.getName().toString().equals("minecraft:chests/simple_dungeon")) {
         // do stuff with evt.getTable()
     }


### PR DESCRIPTION
This does not work without the 'static' keyword.  As per http://www.minecraftforge.net/forum/topic/66581-solved-cant-get-loottable-loading-event-to-fire/

I know it's just a single word, but it will save a lot of time and energy for a lot of coders.