### PR TITLE
Update 'Getting Started with Forge' steps to be based on FG3

### DIFF
--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -6,46 +6,33 @@ This is a simple guide to get you from nothing to a basic mod. The rest of this 
 From Zero to Modding
 --------------------
 
-1. Obtain a source distribution from forge's [files][] site. (Look for the Mdk file type, or Src in older 1.8/1.7 versions).
-2. Extract the downloaded source distribution to an empty directory. You should see a bunch of files, and an example mod is placed in `src/main/java` for you to look at. Only a few of these files are strictly necessary for mod development, and you may reuse these files for all your projects These files are:
+1. Obtain a source distribution from Forge's [files][] site. (Look for the mdk file type, or src in older 1.8/1.7 versions).
+2. Extract the downloaded source distribution to an empty directory. You should see a bunch of files, and an example mod is placed in `src/main/java` for you to look at. Only a few of these files are strictly necessary for mod development, and you may reuse these files for all your projects. These files are:
     * `build.gradle`
     * `gradlew.bat`
     * `gradlew`
     * the `gradle` folder
 3. Move the files listed above to a new folder, this will be your mod project folder.
-4. Open up a command prompt in the folder you created in step (3), then run `gradlew setupDecompWorkspace`. This will download a bunch of artifacts from the internet needed to decompile and build Minecraft and forge. This might take some time, as it will download stuff and then decompile Minecraft. Note that, in general, these things will only need to be downloaded and decompiled once, unless you delete the gradle artifact cache.
-5. Choose your IDE: Forge explicitly supports developing with Eclipse or IntelliJ environments, but any environment, from Netbeans to vi/emacs, can be made to work.
-    * For Eclipse, you should run `gradlew eclipse` - this will download some more artifacts for building eclipse projects and then place the eclipse project artifacts in your current directory.
-    * For IntelliJ, simply import the build.gradle file.
-6. Load your project into your IDE.
-    * For Eclipse, create a workspace anywhere (though the easiest location is one level above your project folder). Then simply import your project folder as a project, everything will be done automatically.
-    * For IntelliJ, you only need to create run configs. You can run `gradlew genIntellijRuns` to do this.
+4. Choose your IDE: Forge explicitly supports developing with Eclipse or IntelliJ environments, but any environment, from Netbeans to vi/emacs, can be made to work.
+    * For Eclipse or IntelliJ, follow the next configuration guides for your respective IDE:
 
-!!! note
-
-    In case you will receive an error while running the task `:decompileMC` ( the fourth step )
-
-    ```
-    Execution failed for task ':decompileMc'.
-    GC overhead limit exceeded
-    ```
-
-    assign more RAM into gradle by adding `org.gradle.jvmargs=-Xmx2G` into the file `~/.gradle/gradle.properties` (create file if doesn't exist). The `~` sign means it's a user's [home directory][]    .
-
-
-[home directory]: https://en.wikipedia.org/wiki/Home_directory#Default_home_directory_per_operating_system "Default user's home folder location for different operation systems"
 [files]: https://files.minecraftforge.net "Forge Files distribution site"
 
-Terminal-free IntelliJ IDEA configuration
-------------------------------------------
+The following configuration guides assume that you have created the project folder, as described in the steps 1 to 3 of the section above, and have selected to use either Eclipse or IntelliJ as your chosen IDE (step 4). Because of that, the numbering starts at 5.
 
-These instructions assume that you have created the project folder as described in the steps 1 to 3 of the section above. Because of that, the numbering starts at 4.
+### IntelliJ IDEA Configuration
 
-4. Launch IDEA and choose to open/import the `build.gradle` file, using the default gradle wrapper choice. While you wait for this process to finish, you can open the gradle panel, which will get filled with the gradle tasks once importing is completed.
-5. Run the `setupDecompWorkspace` task (inside the `forgegradle` task group). It will take a few minutes, and use quite a bit of RAM. If it fails, you can add `-Xmx3G` to the `Gradle VM options` in IDEA's gradle settings window, or edit your global gradle properties.
-6. Once the setup task is done, you will want to run the `genIntellijRuns` task, which will configure the project's run/debug targets. 
-7. After it's done, you should click the blue refresh icon **on the gradle panel** (there's another refresh icon on the main toolbar, but that's not it). This will re-synchronize the IDEA project with the Gradle data, making sure that all the dependencies and settings are up to date.
-8. Finally, assuming you use IDEA 2016 or newer, you will have to fix the classpath module. Go to `Edit configurations` and in both `Minecraft Client` and `Minecraft Server`, change `Use classpath of module` to point to the task with a name like `<project>_main`.
+5. Launch IntelliJ and choose to open/import the `build.gradle` file, using the default gradle wrapper choice. While you wait for this process to finish, you can open the gradle panel, which will get filled with the gradle tasks once importing, and indexing, is completed.
+6. You can now generate the IntelliJ specific run configurations, based on the `runs` section in the `build.gradle`, for launching the Minecraft client and server. This can be done in either of the following ways:
+    * Using IntelliJ's built-in gradle features - simply to right of the screen `Gradle > <Project Name> > Tasks > fg_runs > genIntellijRuns`.
+    * Open up a terminal, Command Prompt or PowerShell in Windows, making sure the current working directory is the folder created in step 3, and running the `gradlew genIntellijRuns` command.
+
+### Eclipse Configuration
+
+5. Open up a terminal, Command Prompt or PowerShell in Windows, and make sure the current working directory is the folder created in step 3.
+6. Run the `gradlew eclipse` command - this will download the required artifacts for building eclipse projects.
+7. Run the `gradlew genEclipseRuns` command - this will generate the Eclipse specific run configurations, based on the `runs` section in the `build.gradle`, for launching the Minecraft client and server.
+8. You are now ready to launch Eclipse and import the folder as an existing project.
 
 If all the steps worked correctly, you should now be able to choose the Minecraft run tasks from the dropdown, and then click the Run/Debug buttons to test your setup.
 
@@ -54,15 +41,15 @@ Customizing Your Mod Information
 
 Edit the `build.gradle` file to customize how your mod is built (the file names, versions, and other things).
 
-!!! important
+!!! Important
 
     **Do not** edit the `buildscript {}` section of the build.gradle file, its default text is necessary for ForgeGradle to function.
 
-Almost anything underneath `apply project: forge` and the `// EDITS GO BELOW HERE` marker can be changed, many things can be removed and customized there as well.
+Almost anything underneath `apply plugin: 'net.minecraftforge.gradle'`, and the `// Only edit below this line` marker, can be changed; many things can be removed and customized there as well.
 
-There is a whole site dedicated to customizing the forge `build.gradle` files - the [ForgeGradle cookbook][]. Once you're comfortable with your mod setup, you'll find many useful recipes there.
+There is a whole site dedicated to customizing the forge `build.gradle` files - the [ForgeGradle CookBook][]. Once you're comfortable with your mod setup, you'll find many useful recipes there.
 
-[forgegradle cookbook]: https://forgegradle.readthedocs.org/en/latest/cookbook/ "The ForgeGradle cookbook"
+[forgegradle cookbook]: https://forgegradle.readthedocs.org/en/latest/cookbook/ "The ForgeGradle CookBook"
 
 ### Simple `build.gradle` Customizations
 
@@ -76,9 +63,8 @@ Building and Testing Your Mod
 -----------------------------
 
 1. To build your mod, run `gradlew build`. This will output a file in `build/libs` with the name `[archivesBaseName]-[version].jar`. This file can be placed in the `mods` folder of a forge enabled Minecraft setup, and distributed.
-2. To test run with your mod, the easiest way is to use the run configs that were generated when you set up your project. Otherwise, you can run `gradlew runClient`. This will launch Minecraft from the `<runDir>` location, including your mod code. There are various customizations to this command. Consult the [ForgeGradle cookbook][] for more information.
-3. You can also run a dedicated server using the server run config, or `gradlew runServer`. This will launch the Minecraft server with it's GUI.
+2. To test run with your mod, the easiest way is to use the run configs that were generated when you set up your project. Otherwise, you can run `gradlew runClient` to launch the Minecraft client, or `gradlew runServer` to launch the Minecraft server. To adjust the setup for these runs, or to create additional, consult the [ForgeGradle CookBook][] for more information.
 
-!!! note
+!!! Note
 
     It is always advisable to test your mod in a dedicated server environment if it is intended to run there.


### PR DESCRIPTION
This updates the `index.md` file under `gettingstarted` to be based on the changes required for FG3.

_**Note:** I plan to update the ForgeGradle CookBook, to add information on customizing, and adding, run configurations, when I get around to it._