### PR TITLE
Updated Getting Started section

### DIFF
--- a/docs/gettingstarted/autoupdate.md
+++ b/docs/gettingstarted/autoupdate.md
@@ -6,7 +6,7 @@ Forge provides a very lightweight opt-in update-checking framework. All it does 
 Getting Started
 ---------------
 
-The first thing you want to do is specify the `updateJSON` parameter in your `@Mod` annotation. The value of this parameter should be a valid URL pointing to an update JSON file. This file can be hosted on your own web server, or on GitHub, or wherever you want, as long as it can be reliably reached by all users of your mod.
+The first thing you want to do is specify the `updateJSONURL` parameter in your `mods.toml` file. The value of this parameter should be a valid URL pointing to an update JSON file. This file can be hosted on your own web server, or on GitHub, or wherever you want, as long as it can be reliably reached by all users of your mod.
 
 Update JSON format
 ------------------
@@ -38,8 +38,6 @@ This is fairly self-explanatory, but some notes:
 * Forge uses an internal algorithm to determine whether one version String of your mod is "newer" than another. Most versioning schemes should be compatible, but see the `ComparableVersion` class if you are concerned about whether your scheme is supported. Adherence to [semantic versioning](https://semver.org/) is highly recommended.
 * The changelog string can be separated into lines using `\n`. Some prefer to include a abbreviated changelog, then link to an external site that provides a full listing of changes.
 * Manually inputting data can be chore. You can configure your `build.gradle` to automatically update this file when building a release, as Groovy has native JSON parsing support. Doing this is left as an exercise to the reader.
-
-Two concrete examples can be seen here for [Charset](https://gist.githubusercontent.com/Meow-J/fe740e287c2881d3bf2341a62a7ce770/raw/bf829cdefc84344d86d1922e2667778112b845b1/update.json) and [Botania Unofficial](https://gist.githubusercontent.com/Meow-J/1299068c775c2b174632534a18b65fb8/raw/42c578cf2303aa76d8900f5fdc6366122549d2a8/update.json).
 
 Retrieving Update Check Results
 -------------------------------

--- a/docs/gettingstarted/autoupdate.md
+++ b/docs/gettingstarted/autoupdate.md
@@ -39,6 +39,8 @@ This is fairly self-explanatory, but some notes:
 * The changelog string can be separated into lines using `\n`. Some prefer to include a abbreviated changelog, then link to an external site that provides a full listing of changes.
 * Manually inputting data can be chore. You can configure your `build.gradle` to automatically update this file when building a release, as Groovy has native JSON parsing support. Doing this is left as an exercise to the reader.
 
+- Some examples can be found here for [nocubes](https://cadiboo.github.io/projects/nocubes/update.json), [Corail Tombstone](https://github.com/Corail31/tombstone_lite/blob/master/update.json) and [Chisels & Bits 2](https://github.com/Aeltumn/Chisels-and-Bits-2/blob/master/update.json).
+
 Retrieving Update Check Results
 -------------------------------
 

--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -31,6 +31,7 @@ Almost anything underneath `apply project: forge` and the `// EDITS GO BELOW HER
 There is a whole site dedicated to customizing the forge `build.gradle` files - the [ForgeGradle cookbook][]. Once you're comfortable with your mod setup, you'll find many useful recipes there.
 
 [forgegradle cookbook]: https://forgegradle.readthedocs.org/en/latest/cookbook/ "The ForgeGradle cookbook"
+[files]: https://files.minecraftforge.net "Forge Files distribution site"
 
 ### Simple `build.gradle` Customizations
 
@@ -39,6 +40,7 @@ These customizations are highly recommended for all projects.
 * To change the name of the file you build - edit the value of `archivesBaseName` to suit.
 * To change your "maven coordinates" - edit the value of `group` as well.
 * To change the version number - edit the value of `version`.
+* To update the run configurations - replace all occurrences of `examplemod` to the mod id of your mod.
 
 Building and Testing Your Mod
 -----------------------------

--- a/docs/gettingstarted/structuring.md
+++ b/docs/gettingstarted/structuring.md
@@ -21,9 +21,14 @@ This file defines the metadata of your mod. Its information may be viewed by use
 
 The `mods.toml` file is formatted as TOML, the example mods.toml file in the MDK provides comments explaining the contents of the file. It should be stored as `src/main/resources/META-INF/mods.toml`. A basic `mods.toml`, describing one mod, may look like this:
 
+    # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
     modLoader="javafml"
+    # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
     loaderVersion="[28,)]"
+    # A URL to refer people to when problems occur with this mod
     issueTrackerURL="github.com/MinecraftForge/MinecraftForge/issues"
+    # If the mods defined in this file should show as seperate resource packs
+    showAsResourcePack=false
     
     [[mods]]
       modId="examplemod"

--- a/docs/gettingstarted/structuring.md
+++ b/docs/gettingstarted/structuring.md
@@ -19,8 +19,8 @@ The `mods.toml` file
 
 This file defines the metadata of your mod. Its information may be viewed by users from the main screen of the game through the Mods button. A single info file can describe several mods.
 
-The `mods.toml` file is formatted as TOML, the example mods.toml file in the MDK provides comments explaining the contents of the file. It should be stored as `src/main/resources/META-INF/mods.toml`. A basic `mods.toml`, describing one mod, may look like this:
-
+The `mods.toml` file is formatted as [TOML](https://github.com/toml-lang/toml), the example mods.toml file in the MDK provides comments explaining the contents of the file. It should be stored as `src/main/resources/META-INF/mods.toml`. A basic `mods.toml`, describing one mod, may look like this:
+```toml
     # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
     modLoader="javafml"
     # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
@@ -29,7 +29,7 @@ The `mods.toml` file is formatted as TOML, the example mods.toml file in the MDK
     issueTrackerURL="github.com/MinecraftForge/MinecraftForge/issues"
     # If the mods defined in this file should show as seperate resource packs
     showAsResourcePack=false
-    
+
     [[mods]]
       modId="examplemod"
       version="1.0.0.0"
@@ -42,20 +42,21 @@ The `mods.toml` file is formatted as TOML, the example mods.toml file in the MDK
       description='''
       Lets you craft dirt into diamonds. This is a traditional mod that has existed for eons. It is ancient. The holy Notch created it. Jeb rainbowfied it. Dinnerbone made it upside down. Etc.
       '''
-      
+
       [[dependencies.examplemod]]
         modId="forge"
         mandatory=true
         versionRange="[28,)"
         ordering="NONE"
         side="BOTH"
-        
+
       [[dependencies.examplemod]]
         modId="minecraft"
         mandatory=true
         versionRange="[1.14.4]"
         ordering="NONE"
         side="BOTH"
+```
 
 The default Gradle configuration replaces `${file.jarVersion}` with the project version, but *only* within `mods.toml`, so you should use those instead of directly writing them out. Here is a table of attributes that may be given to a mod, where `mandatory` means there is no default and the absence of the property causes an error.
 

--- a/docs/gettingstarted/structuring.md
+++ b/docs/gettingstarted/structuring.md
@@ -24,6 +24,7 @@ The `mods.toml` file is formatted as [TOML](https://github.com/toml-lang/toml), 
     # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
     modLoader="javafml"
     # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
+    # Forge for 1.14.4 is version 28
     loaderVersion="[28,)]"
     # A URL to refer people to when problems occur with this mod
     issueTrackerURL="github.com/MinecraftForge/MinecraftForge/issues"

--- a/docs/gettingstarted/structuring.md
+++ b/docs/gettingstarted/structuring.md
@@ -14,49 +14,60 @@ Pick a unique package name. If you own a URL associated with your project, you c
 
 After the top level package (if you have one) you append a unique name for your mod, such as `examplemod`. In our case it will end up as `com.example.examplemod`.
 
-The `mcmod.info` file
+The `mods.toml` file
 -------------------
 
-This file defines the metadata of your mod. Its information may be viewed by users from the main screen of the game through the Mods button. A single info file can describe several mods. When a mod is annotated by the `@Mod` annotation, it may define the `useMetadata` property, which defaults to `false`. When `useMetadata` is `true`, the metadata within `mcmod.info` overrides whatever has been defined in the annotation.
+This file defines the metadata of your mod. Its information may be viewed by users from the main screen of the game through the Mods button. A single info file can describe several mods.
 
-The `mcmod.info` file is formatted as JSON, where the root element is a list of objects and each object describes one modid. It should be stored as `src/main/resources/mcmod.info`. A basic `mcmod.info`, describing one mod, may look like this:
+The `mods.toml` file is formatted as TOML, the example mods.toml file in the MDK provides comments explaining the contents of the file. It should be stored as `src/main/resources/META-INF/mods.toml`. A basic `mods.toml`, describing one mod, may look like this:
 
-    [{
-      "modid": "examplemod",
-      "name": "Example Mod",
-      "description": "Lets you craft dirt into diamonds. This is a traditional mod that has existed for eons. It is ancient. The holy Notch created it. Jeb rainbowfied it. Dinnerbone made it upside down. Etc.",
-      "version": "1.0.0.0",
-      "mcversion": "1.10.2",
-      "logoFile": "assets/examplemod/textures/logo.png",
-      "url": "minecraftforge.net/",
-      "updateJSON": "minecraftforge.net/versions.json",
-      "authorList": ["Author"],
-      "credits": "I'd like to thank my mother and father."
-    }]
+    modLoader="javafml"
+    loaderVersion="[28,)]"
+    issueTrackerURL="github.com/MinecraftForge/MinecraftForge/issues"
+    
+    [[mods]]
+      modId="examplemod"
+      version="1.0.0.0"
+      displayName="Example Mod"
+      updateJSONURL="minecraftforge.net/versions.json"
+      displayURL="minecraftforge.net"
+      logoFile="assets/examplemod/textures/logo.png"
+      credits="I'd like to thank my mother and father."
+      authors="Author"
+      description='''
+      Lets you craft dirt into diamonds. This is a traditional mod that has existed for eons. It is ancient. The holy Notch created it. Jeb rainbowfied it. Dinnerbone made it upside down. Etc.
+      '''
+      
+      [[dependencies.examplemod]]
+        modId="forge"
+        mandatory=true
+        versionRange="[28,)"
+        ordering="NONE"
+        side="BOTH"
+        
+      [[dependencies.examplemod]]
+        modId="minecraft"
+        mandatory=true
+        versionRange="[1.14.4]"
+        ordering="NONE"
+        side="BOTH"
 
-The default Gradle configuration replaces `${version}` with the project version, and `${mcversion}` with the Minecraft version, but *only* within `mcmod.info`, so you should use those instead of directly writing them out. Here is a table of attributes that may be given to a mod, where `required` means there is no default and the absence of the property causes an error. In addition to the required properties, you should also define `description`, `version`, `mcversion`, `url`, and `authorList`.
+The default Gradle configuration replaces `${file.jarVersion}` with the project version, but *only* within `mods.toml`, so you should use those instead of directly writing them out. Here is a table of attributes that may be given to a mod, where `mandatory` means there is no default and the absence of the property causes an error.
 
 |     Property |   Type   | Default  | Description |
 |-------------:|:--------:|:--------:|:------------|
-|        modid |  string  | required | The modid this description is linked to. If the mod is not loaded, the description is ignored. |
-|         name |  string  | required | The user-friendly name of this mod. |
-|  description |  string  |   `""`   | A description of this mod in 1-2 paragraphs. |
-|      version |  string  |   `""`   | The version of the mod. |
-|    mcversion |  string  |   `""`   | The Minecraft version. |
-|          url |  string  |   `""`   | A link to the mod's homepage. |
-|    updateUrl |  string  |   `""`   | Defined but unused. Superseded by updateJSON. |
-|   updateJSON |  string  |   `""`   | The URL to a [version JSON](autoupdate#forge-update-checker). |
-|   authorList | [string] |   `[]`   | A list of authors to this mod. |
-|      credits |  string  |   `""`   | A string that contains any acknowledgements you want to mention. |
+|        modid |  string  | mandatory | The modid this file is linked to. |
+|      version |  string  | mandatory | The version of the mod. It should be just numbers seperated by dots, ideally conforming to [Semantic Versioning](https://semver.org/). |
+|  displayName |  string  | mandatory | The user-friendly name of this mod. |
+| updateJSONURL |  string  |   `""`   | The URL to a [version JSON](autoupdate#forge-update-checker). |
+|   displayURL |  string  |   `""`   | A link to the mod's homepage. |
 |     logoFile |  string  |   `""`   | The path to the mod's logo. It is resolved on top of the classpath, so you should put it in a location where the name will not conflict, maybe under your own assets folder. |
-|  screenshots | [string] |   `[]`   | A list of images to be shown on the info page. Currently unimplemented. |
-|       parent |  string  |   `""`   | The modid of a parent mod, if applicable. Using this allows modules of another mod to be listed under it in the info page, like BuildCraft. |
-| useDependencyInformation |  boolean |  `false` | If true and `Mod.useMetadata`, the below 3 lists of dependencies will be used. If not, they do nothing. |
-| requiredMods | [string] |   `[]`   | A list of modids. If one is missing, the game will crash. This **does not affect the _ordering_ of mod loading!** To specify ordering as well as requirement, have a coupled entry in `dependencies`. |
-| dependencies | [string] |   `[]`   | A list of modids. All of the listed mods will load *before* this one. If one is not present, nothing happens. |
-|   dependants | [string] |   `[]`   | A list of modids. All of the listed mods will load *after* this one. If one is not present, nothing happens. |
+|      credits |  string  |   `""`   | A string that contains any acknowledgements you want to mention. |
+|      authors |  string  |   `""`   | The authors to this mod. |
+|  description |  string  | mandatory | A description of this mod. |
+| dependencies | [list] |   `[]`   | A list of dependencies of this mod. |
 
-A good example `mcmod.info` that uses many of these properties is [BuildCraft](https://gist.github.com/anonymous/05ad9a1e0220bbdc25caed89ef0a22d2).
+<a name="version-ranges" style="color: inherit; text-decoration: inherit">\* All version ranges use the [Maven Version Range Specification](https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html).</a>
 
 The Mod File
 ------------
@@ -67,31 +78,7 @@ and will contain some special indicators marking it as such.
 What is `@Mod`?
 -------------
 
-This is an annotation indicating to the Forge Mod Loader that the class is a Mod entry point. It contains various metadata about the mod. It also designates the class that will receive `@EventHandler` events.
-
-Here is a table of the properties of `@Mod`:
-
-|                         Property |        Type        |    Default     | Description |
-|---------------------------------:|:------------------:|:--------------:|:------------|
-|                            modid |       String       |    required    | A unique identifier for the mod. It must be lowercased, and will be truncated to 64 characters in length. |
-|                             name |       String       |       ""       | A user-friendly name for the mod. |
-|                          version |       String       |       ""       | The version of the mod. It should be just numbers seperated by dots, ideally conforming to [Semantic Versioning](https://semver.org/). Even if `useMetadata` is set to `true`, it's a good idea to put the version here anyways. |
-|                     dependencies |       String       |       ""       | Dependencies for the mod. The specification is described in the Forge `@Mod` javadoc:<br><blockquote><p>A dependency string can start with the following four prefixes: `"before"`, `"after"`, `"required-before"`, `"required-after"`; then `":"` and the `modid`.</p><p>Optionally, a version range can be specified for the mod by adding `"@"` and then the version range.[\*](#version-ranges)</p><p>If a "required" mod is missing, or a mod exists with a version outside the specified range, the game will not start and an error screen will tell the player which versions are required.</p>
-|                      useMetadata |       boolean      |      false     | If set to true, properties in `@Mod` will be overridden by `mcmod.info`. |
-| clientSideOnly<br>serverSideOnly | boolean<br>boolean | false<br>false | If either is set to `true`, the jar will be skipped on the other side, and the mod will not load. If both are true, the game crashes. |
-|        acceptedMinecraftVersions |       String       |       ""       | The version range of Minecraft the mod will run on.[\*](#version-ranges) An empty string will match all versions. |
-|         acceptableRemoteVersions |       String       |       ""       | Specifies a remote version range that this mod will accept as valid.[\*](#version-ranges) `""` Matches the current version, and `"*"` matches all versions. Note that `"*"` matches even when the mod is not present on the remote side at all. |
-|           acceptableSaveVersions |       String       |       ""       | A version range specifying compatible save version information.[\*](#version-ranges) If you follow an unusual version convention, use `SaveInspectionHandler` instead. |
-|           certificateFingerprint |       String       |       ""       | See the tutorial on [jar signing](../concepts/jarsigning.md). |
-|                      modLanguage |       String       |     "java"     | The programming language the mod is written in. Can be either `"java"` or `"scala"`. |
-|               modLanguageAdapter |       String       |       ""       | Path to a language adapter for the mod. The class must have a default constructor and must implement `ILanguageAdapter`. If it doesn't, Forge will crash. If set, overrides `modLanguage`. |
-|                 canBeDeactivated |       boolean      |      false     | This is not implemented, but if the mod could be deactivated (e.g. a minimap mod), this would be set to `true` and the mod would [receive](../events/intro.md#creating-an-event-handler) `FMLDeactivationEvent` to perform cleanup tasks. |
-|                       guiFactory |       String       |       ""       | Path to the mod's GUI factory, if one exists. GUI factories are used to make custom config screens, and must implement `IModGuiFactory`. For an example, look at `FMLConfigGuiFactory`. |
-|                       updateJSON |       String       |       ""       | URL to an update JSON file. See [Forge Update Checker](autoupdate.md) |
-
-<a name="version-ranges" style="color: inherit; text-decoration: inherit">\* All version ranges use the [Maven Version Range Specification](https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html).</a>
-
-You can find an example mod in the [Forge src download](https://files.minecraftforge.net/).
+This is an annotation indicating to the Forge Mod Loader that the class is a Mod entry point. The `@Mod` annotation's value should match a mod id in the `src/main/resources/META-INF/mods.toml` file.
 
 Keeping Your Code Clean Using Sub-packages
 ------------------------------------------
@@ -113,8 +100,8 @@ A common class naming scheme allows easier deciphering of what a class is, and a
 
 For Example:
 
-* An `Item` called `PowerRing` would be in an `item` package, with a class name of `ItemPowerRing`.
-* A `Block` called `NotDirt` would be in a `block` package, with a class name of `BlockNotDirt`.
-* Finally, a `TileEntity` for a block called `SuperChewer` would be a `tile` or `tileentity` package, with a class name of `TileSuperChewer`.
+* An `Item` called `PowerRing` would be in an `item` package, with a class name of `PowerRingItem`.
+* A `Block` called `NotDirt` would be in a `block` package, with a class name of `NotDirtBlock`.
+* Finally, a `TileEntity` for a block called `SuperChewer` would be a `tile` or `tileentity` package, with a class name of `SuperChewerTile`.
 
-Prepending your class names with what *kind* of object they are makes it easier to figure out what a class is, or guess the class for an object.
+Appending your class names with what *kind* of object they are makes it easier to figure out what a class is, or guess the class for an object.


### PR DESCRIPTION
I've updated the getting started section to 1.13, changes made:
- index.md: Fixed link to files distribution site and added note to replace "examplemod" with mod id in run configs.
- autoupdate.md: Removed 2 dead links.
- structuring.md: Replaced mcmod.info explaination with new mods.toml explaination. Updated ``@Mod`` explaination. Updated class naming scheme from prefix to suffix.