### PR TITLE
Add explaination about side-only mods and network version predicates

### DIFF
--- a/docs/networking/simpleimpl.md
+++ b/docs/networking/simpleimpl.md
@@ -21,6 +21,14 @@ public static final SimpleChannel INSTANCE = NetworkRegistry.newSimpleChannel(
 The first argument is a name for the channel. The second argument is a `Supplier<String>` returning the current network protocol version. The third and fourth arguments respectively are `Predicate<String>` checking whether an incoming connection protocol version is network-compatible with the client or server, respectively.
 Here, we simply compare with the `PROTOCOL_VERSION` field directly, meaning that the client and server `PROTOCOL_VERSION`s must always match or FML will deny login.
 
+The Version Checker
+-------------------
+If your mod does not require the other side to have a specific network channel, or to be a Forge instance at all, you should take care that you properly define your version compatibility checkers (the `Predicate<String>` parameters) to handle additional "meta-versions" (defined in `NetworkRegistry`) that can be received by the version checker. These are:
+* `ABSENT` - if this channel is missing on the other endpoint. Note that in this case, the endpoint is still a Forge endpoint, and may have other mods.
+* `ACCEPTVANILLA` - if the endpoint is a vanilla (or non-Forge) endpoint.
+
+Returning `false` for both means that this channel must be present on the other endpoint. If you just copy the code above, this is what it does. Note that these values are also used during the list ping compatibility check, which is responsible for showing the green check / red cross in the multiplayer server select screen.
+
 Registering Packets
 -------------------
 


### PR DESCRIPTION
Added documentation for the displaytest extensionpoint, which needs to be overwritten if your mod is side-only.

Also added explanation about network version predicates with SimpleImpl, and how they are affected/called if the mod is not present on the other side.