### PR TITLE
Updated Events section

### DIFF
--- a/docs/events/intro.md
+++ b/docs/events/intro.md
@@ -90,7 +90,7 @@ Many events have different variations of themselves, these can be different but 
 Mod Event Bus
 -------------
 
-The mod event bus is primarily meant for listening to lifecycle events in which mods should initialize. Many of these events are also ran in parallel so mods can be initialized at the same time. This does mean you can't directly execute code from other mods in these events, use the `InterModEnqueueEvent` and `InterModProcessEvent` events for that.
+The mod event bus is primarily meant for listening to lifecycle events in which mods should initialize. Many of these events are also ran in parallel so mods can be initialized at the same time. This does mean you can't directly execute code from other mods in these events, use the `InterModComms` system for that.
 
 These are the four most commonly used events that are called during mod initialization on the mod event bus:
 * FMLCommonSetupEvent

--- a/docs/events/intro.md
+++ b/docs/events/intro.md
@@ -90,9 +90,9 @@ Many events have different variations of themselves, these can be different but 
 Mod Event Bus
 -------------
 
-The mod event bus is primarily meant for listening to lifecycle events in which mods should initialize. Many of these events are also ran in parallel so mods can be initialized at the same time. This does mean you can't directly execute code from other mods in these events, use the `InterModComms` system for that.
+The mod event bus is primarily used for listening to lifecycle events in which mods should initialize. Many of these events are also ran in parallel so mods can be initialized at the same time. This does mean you can't directly execute code from other mods in these events, use the `InterModComms` system for that.
 
-These are the four most commonly used events that are called during mod initialization on the mod event bus:
+These are the four most commonly used lifecycle events that are called during mod initialization on the mod event bus:
 * FMLCommonSetupEvent
 * FMLClientSetupEvent & FMLDedicatedServerSetupEvent
 * InterModEnqueueEvent
@@ -100,3 +100,13 @@ These are the four most commonly used events that are called during mod initiali
 
 !!! note
     The `FMLClientSetupEvent` and `FMLDedicatedServerSetupEvent` are only called on their respective distribution.
+
+These four lifecycle events are all ran in parallel. If you want to run code on the main thread during these events you can use the `DeferredWorkQueue` to do so.
+
+Next to the lifecycle events there are a few miscellaneous events that are fired on the mod event bus where you can register, set up or initialize various things. Most of these events are not ran in parallel in contrast to the lifecycle events. A few examples:
+* ColorHandlerEvent
+* ModelBakeEvent
+* TextureStitchEvent
+* RegistryEvent
+
+A good rule of thumb: events are fired on the mod event bus when they should be handled during initialization of a mod.

--- a/docs/events/intro.md
+++ b/docs/events/intro.md
@@ -5,7 +5,7 @@ Forge uses an event bus that allows mods to intercept events from various vanill
 
 Example: An event can be used to perform an action when a Vanilla stick is right clicked.
 
-The main event bus used for most events is located at `MinecraftForge.EVENT_BUS`. 
+The main event bus used for most events is located at `MinecraftForge.EVENT_BUS`. There is another event bus for mod specific events located at `FMLJavaModLoadingContext.get().getModEventBus()`.
 
 An event handler is a class that contains one or more `public void` member methods that are marked with the `@SubscribeEvent` annotation.
 
@@ -43,8 +43,21 @@ which must be registered like this: `MinecraftForge.EVENT_BUS.register(MyStaticF
 
 A class may be annotated with the `@Mod.EventBusSubscriber` annotation. Such a class is automatically registered to `MinecraftForge.EVENT_BUS` when the `@Mod` class itself is constructed. This is essentially equivalent to adding `MinecraftForge.EVENT_BUS.register(AnnotatedClass.class);` at the end of the `@Mod` class's constructor.
 
+You can pass the bus you want to listen to to the `@Mod.EventBusSubscriber` annotation. You can also specify the `Dist`s to load this event subscriber on. This can be used to not load Client specific event subscribers on the dedicated server.
+
+An example for a static event listener listening to `RenderWorldLastEvent` which will only be called on the Client:
+```java
+@Mod.EventBusSubscriber(Dist.CLIENT)
+public class MyStaticClientOnlyEventHandler {
+	@SubscribeEvent
+	public static void drawLast(RenderWorldLastEvent event) {
+		System.out.println("Drawing!");
+	}
+}
+```
+
 !!! note
-    This does not register an instance of the class; it registers the class itself (i.e. the event handling methods must be static).
+    This does not register an instance of the class; it registers the class itself (i.e. the event handling methods must be static.
 
 Canceling
 ---------

--- a/docs/events/intro.md
+++ b/docs/events/intro.md
@@ -5,7 +5,9 @@ Forge uses an event bus that allows mods to intercept events from various vanill
 
 Example: An event can be used to perform an action when a Vanilla stick is right clicked.
 
-The main event bus used for most events is located at `MinecraftForge.EVENT_BUS`. There is another event bus for mod specific events located at `FMLJavaModLoadingContext.get().getModEventBus()`.
+The main event bus used for most events is located at `MinecraftForge.EVENT_BUS`. There is another event bus for mod specific events located at `FMLJavaModLoadingContext.get().getModEventBus()` that you should only use in specific cases, more information about this bus can be found below.
+
+Every event is fired on one of these busses, most events are fired on the main event bus but some are fired on the mod specfic events bus.
 
 An event handler is a class that contains one or more `public void` member methods that are marked with the `@SubscribeEvent` annotation.
 
@@ -22,7 +24,7 @@ public class MyForgeEventHandler {
 ```
 This event handler listens for the `EntityItemPickupEvent`, which is, as the name states, posted to the event bus whenever an `Entity` picks up an item.
 
-To register this event handler, use `MinecraftForge.EVENT_BUS.register()` and pass it an instance of your event handler class.
+To register this event handler, use `MinecraftForge.EVENT_BUS.register()` and pass it an instance of your event handler class. If you want to register this handler to the mod specific event bus you should use `FMLJavaModLoadingContext.get().getModEventBus().register()` instead.
 
 ### Static Event Handlers
 
@@ -57,7 +59,7 @@ public class MyStaticClientOnlyEventHandler {
 ```
 
 !!! note
-    This does not register an instance of the class; it registers the class itself (i.e. the event handling methods must be static.
+    This does not register an instance of the class; it registers the class itself (i.e. the event handling methods must be static).
 
 Canceling
 ---------
@@ -84,3 +86,17 @@ Sub Events
 ----------
 
 Many events have different variations of themselves, these can be different but all based around one common factor (e.g. `PlayerEvent`) or can be an event that has multiple phases (e.g. `PotionBrewEvent`). Take note that if you listen to the parent event class, you will receive calls to your method for *all* subclasses.
+
+Mod Event Bus
+-------------
+
+The mod event bus is primarily meant for listening to lifecycle events in which mods should initialize. Many of these events are also ran in parallel so mods can be initialized at the same time. This does mean you can't directly execute code from other mods in these events, use the `InterModEnqueueEvent` and `InterModProcessEvent` events for that.
+
+These are the four most commonly used events that are called during mod initialization on the mod event bus:
+* FMLCommonSetupEvent
+* FMLClientSetupEvent & FMLDedicatedServerSetupEvent
+* InterModEnqueueEvent
+* InterModProcessEvent
+
+!!! note
+    The `FMLClientSetupEvent` and `FMLDedicatedServerSetupEvent` are only called on their respective distribution.


### PR DESCRIPTION
I'm going to give every section a pass getting it up-to-date with 1.14 whenever I've got some time.

Here are some tiny improvements to the Events section, I've added some information and an example on how to use the properties of the Mod.EventBusSubscriber annotation to your advantage to register client-only events. This will hopefully aid people separating their client/common classes because they use the annotation instead.