### PR TITLE
Change assets to data.  Add note about common vanilla format for filename

### DIFF
--- a/docs/utilities/recipes.md
+++ b/docs/utilities/recipes.md
@@ -5,7 +5,7 @@ With the update to Minecraft 1.12, Mojang introduced a new data-driven recipe sy
 
 Loading Recipes
 ---------------
-Forge will load all recipes which can be found within the `./data/<modid>/recipes/` folder. You can call these files whatever you want, thought the vanilla convention is to name them after the output item. For multiple recipes from different sources (Smelting, Crafting, etc) one vanilla convention is to use `item_name_from_smelting.json`.  This name is also used as the registration key, but does not affect the operation of the recipe.
+Forge will load all recipes which can be found within the `./data/<modid>/recipes/` folder. You can call these files whatever you want, thought the vanilla convention is to name them after the output item. For multiple recipes from different sources (Smelting, Crafting, etc) one vanilla convention is to use `item_name_from_smelting.json`. This name is also used as the registration key, but does not affect the operation of the recipe.
 
 !!! note
 

--- a/docs/utilities/recipes.md
+++ b/docs/utilities/recipes.md
@@ -5,7 +5,7 @@ With the update to Minecraft 1.12, Mojang introduced a new data-driven recipe sy
 
 Loading Recipes
 ---------------
-Forge will load all recipes which can be found within the `./assets/<modid>/recipes/` folder. You can call these files whatever you want, thought the vanilla convention is to name them after the output item. This name is also used as the registration key, but does not affect the operation of the recipe.
+Forge will load all recipes which can be found within the `./data/<modid>/recipes/` folder. You can call these files whatever you want, thought the vanilla convention is to name them after the output item. For multiple recipes from different sources (Smelting, Crafting, etc) one vanilla convention is to use `item_name_from_smelting.json`.  This name is also used as the registration key, but does not affect the operation of the recipe.
 
 !!! note
 


### PR DESCRIPTION
Per the minecraft json files, recipes appear to be in the data directory, not assets.

Also, vanilla filenames show things like diamond_from_smelting.json, so adding that as a recommendation.