### PR TITLE
Added a legacy category, addresses #254 and #216

### DIFF
--- a/docs/legacy/index.md
+++ b/docs/legacy/index.md
@@ -7,7 +7,9 @@ Forge has existed for years and you can still easily access builds of Forge for 
 
     These old documentation sites are for reference purposes only. Do not ask for help with old versions on the Forge discord or the Forge forums. **You will not receive support when you are using older versions.**
 
+
 ### List of Previously Documented versions
+
 Unfortunately not all versions were used for a significant amount of time and the documentation for that version may be incomplete. Whenever a new version is released the documentation from the previous version is copied and adjusted over time to include new and updated information. When a version wasn't supported for long the information was never updated, the accuracy percentages represent how much of the information that should have been updated was actually updated.
 
 |    Version    |  Accuracy  |                  Link                     |

--- a/docs/legacy/index.md
+++ b/docs/legacy/index.md
@@ -1,0 +1,16 @@
+Documentation for Legacy Versions
+=================================
+
+Forge has existed for years and you can still easily access builds of Forge for Minecraft versions as old as Minecraft 1.1. There are significant differences between each and every version and it would be an impossible task to support so many different versions. Therefore, Forge uses an LTS system where a previous major Minecraft version is deemed as "LTS" (Long Term Support). Only the latest version and any current LTS versions will have easily accessible documentation and be included in the version dropdown in the sidebar. However, some older versions were LTS once or the latest version at some point and had documentation written, links to old sites with documentation for those versions can be found here.
+
+!!! important
+
+    These old documentation sites are for reference purposes only. Do not ask for help with old versions on the Forge discord or the Forge forums. **You will not receive support when you are using older versions.**
+
+### List of Previously Documented versions
+Unfortunately not all versions were used for a significant amount of time and the documentation for that version may be incomplete. Whenever a new version is released the documentation from the previous version is copied and adjusted over time to include new and updated information. When a version wasn't supported for long the information was never updated, the accuracy percentages represent how much of the information that should have been updated was actually updated.
+
+|    Version    |  Accuracy  |                  Link                     |
+|:-------------:|:----------:|:------------------------------------------|
+|    1.12.x     |   100%     | https://mcforge.readthedocs.io/en/1.12.x/ |
+|    1.13.x     |    10%     | https://mcforge.readthedocs.io/en/1.13.x/ |

--- a/docs/legacy/porting1214.md
+++ b/docs/legacy/porting1214.md
@@ -1,0 +1,6 @@
+Porting from Minecraft 1.12 to Minecraft 1.13/1.14
+==================================================
+
+Due to major rewrites to Forge happening during the lifetime of 1.13 it never saw much usage and instead most mods ported directly to 1.14 skipping over 1.13. Therefore this guide will focus on porting from 1.12 directly to 1.14.
+
+_Full documentation on porting from 1.12 to 1.14 is still work in progress, for now we suggest having a look at [a primer written by williewillus](https://gist.github.com/williewillus/353c872bcf1a6ace9921189f6100d09a)!_

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,9 @@ pages:
   - Contributing to Forge:
     - Getting Started: 'forgedev/index.md'
     - PR Guidelines: 'forgedev/prguidelines.md'
+  - Legacy Versions:
+    - Home: 'legacy/index.md'
+    - Porting from 1.12 to 1.13/1.14: 'legacy/porting1214.md'
 
 # Do not edit in PRs below here
 site_name: Forge Documentation


### PR DESCRIPTION
I've set up a concept for a legacy category as suggested in #254. This category also includes a page linking to the 1.12 -> 1.14 primer by @williewillus as suggested in #216 .

I started modding recently after the release of 1.14.x so I don't know anything about the state of the documentation but I assume that the documentation for 1.12 was accurate.

I don't know if my accuracy score for old versions is a good idea but I think it is needed to inform the reader that some documentation versions might not be very accurate. (especially 1.13.x)