### PR TITLE
Updated the folder in which the recepies are in

### DIFF
--- a/docs/utilities/recipes.md
+++ b/docs/utilities/recipes.md
@@ -5,7 +5,7 @@ With the update to Minecraft 1.12, Mojang introduced a new data-driven recipe sy
 
 Loading Recipes
 ---------------
-Forge will load all recipes which can be found within the `./assets/<modid>/recipes/` folder. You can call these files whatever you want, thought the vanilla convention is to name them after the output item. This name is also used as the registration key, but does not affect the operation of the recipe.
+Forge will load all recipes which can be found within the `./resources/data/<modid>/recipes/` folder. You can call these files whatever you want, thought the vanilla convention is to name them after the output item. This name is also used as the registration key, but does not affect the operation of the recipe.
 
 !!! note
 


### PR DESCRIPTION
Hi, new here. 
After a search on the internet, it seems that the path for the recipes folder in the docs is wrong in 1.15.x. I checked it and the previous path didn't work for me and this one did(as far as I know its a 1.14.x change and in the docs, for 1.14.x it has already been changed)

I changed the path from ./assets/<modid>/recipes/ to ./resources/data/<modid>/recipes/

 Thanks for Animefan8888 in [this forum](https://www.minecraftforge.net/forum/topic/76325-1144solved-recipes-doesnt-work/).