### PR TITLE
[1.15.x] ITickable -> ITickableTileEntity

### DIFF
--- a/docs/tileentities/tileentity.md
+++ b/docs/tileentities/tileentity.md
@@ -55,10 +55,10 @@ Use them to read and write to the fields in your tile entity class.
 
 ## Ticking `TileEntities`
 
-If you need a ticking `TileEntity`, for example to keep track of the progress during a smelting process, you need to add the `net.minecraft.util.ITickable` interface to your `TileEntity`.
+If you need a ticking `TileEntity`, for example to keep track of the progress during a smelting process, you need to add the `net.minecraft.tileentity.ITickableTileEntity` interface to your `TileEntity`.
 Now you can implement all your calculations within
 ```JAVA
-ITickable#update()
+ITickableTileEntity#tick()
 ```
 
 !!! note


### PR DESCRIPTION
In 1.15.+, the correct interface to make tile entity tickable is `ITickableTileEntity`.

Close MinecraftForge/Documentation#281