### PR TITLE
Update Getting Started

### DIFF
--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -52,7 +52,7 @@ Building and Testing Your Mod
 
 1. To build your mod, run `gradlew build`. This will output a file in `build/libs` with the name `[archivesBaseName]-[version].jar`. This file can be placed in the `mods` folder of a forge enabled Minecraft setup, and distributed.
 2. To test run with your mod, the easiest way is to use the run configs that were generated when you set up your project. Otherwise, you can run `gradlew runClient`. This will launch Minecraft from the `<runDir>` location, including your mod code. There are various customizations to this command. Consult the [ForgeGradle cookbook][] for more information.
-3. You can also run a dedicated server using the server run config, or `gradlew runServer`. This will launch the Minecraft server with its GUI.
+3. You can also run a dedicated server using the server run config, or `gradlew runServer`. This will launch the Minecraft server with its GUI. It will fail during the first time you run it, and you will need agree to the Minecraft EULA and edit `run/eula.txt` in order to run the server.
 
 !!! note
 

--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -14,12 +14,13 @@ From Zero to Modding
     * the `gradle` folder
 3. Move the files listed above to a new folder, this will be your mod project folder.
 4. Choose your IDE:
-    * Forge explicitly supports developing with Eclipse or IntelliJ environments, but any environment, from Netbeans to vi/emacs, can be made to work.
+    * Forge explicitly supports developing with Eclipse, IntelliJ or Visual Studio Code environments, but any environment, from Netbeans to vi/emacs, can be made to work.
     * For both Intellij IDEA and Eclipse their Gradle integration will handle the rest of the initial workspace setup, this includes downloading packages from Mojang, MinecraftForge, and a few other software sharing sites.
     * For most, if not all, changes to the build.gradle file to take effect Gradle will need to be invoked to re-evaluate the project, this can be done through Refresh buttons in the Gradle panels of both the previously mentioned IDEs.
 5. Generating IDE Launch/Run Configurations:
     * For Eclipse, run the `genEclipseRuns` gradle task (`gradlew genEclipseRuns`). This will generate the Launch Configurations and download any required assets for the game to run. After this has finished refresh your project.
     * For IntelliJ, run the `genIntellijRuns` gradle task (`gradlew genIntellijRuns`). This will generate the Run Configurations and download any required assets for the game to run. After this has finished edit your Configurations to fix the "module not specified" error by changing selecting your "main" module.
+    * For Visual Studio Code, run the `genVSCodeRuns` gradle task (`gradlew genVSCodeRuns`). This will generate the Launch Configurations and download any required assets for the game to run.
 
 Customizing Your Mod Information
 --------------------------------


### PR DESCRIPTION
Fix indentation so the lists should show correctly on Read The Docs

  - The style guides say to have two spaces for indentation, I used four spaces here just to be consistent with many of other pages in this guide (at least also with rest of this page)

Mention command for generating configurations in VS Code
Mention to edit `eula.txt` for testing the server

  - Think it is helpful to mention it, and it does not seem to appear in the error message