### PR TITLE
Added Model Data documentation

### DIFF
--- a/docs/models/advanced/ibakedmodel.md
+++ b/docs/models/advanced/ibakedmodel.md
@@ -38,16 +38,20 @@ See [Perspective][].
 
 ### `getQuads`
 
-This is the main method of `IBakedModel`. It returns `BakedQuad`s, which contain the low-level vertex data that will be used to render the model. If the model is being rendered as a block, then the `IBlockState` passed in is non-null. Additionally, [`Block::getExtendedState`][extended blockstates] is called to create the passed `IBlockState`, which allows for arbitrary data to be passed from the block to the model. If the model is being rendered as an item, the `ItemOverrideList` returned from `getOverrides` is responsible for handling the state of the item, and the `IBlockState` parameter will be `null`.
+This is the main method of `IBakedModel`. It returns `BakedQuad`s, which contain the low-level vertex data that will be used to render the model. If the model is being rendered as a block, then the `IBlockState` passed in is non-null. Additionally, there is a [`IModelData`][modeldata] parameter which contains the data which is passed from the `TileEntity` allowing arbitrary data to be passed from the block to the model. If the model is being rendered as an item, the `ItemOverrideList` returned from `getOverrides` is responsible for handling the state of the item, and the `IBlockState` parameter will be `null`.
 
-The `EnumFacing` passed in is used for face culling. If the block against the given side of the block being rendered is opaque, then the faces associated with that side are not rendered. If that parameter is `null`, all faces not associated with a side are returned (that will never be culled).
+The `Direction` passed in is used for face culling. If the block against the given side of the block being rendered is opaque, then the faces associated with that side are not rendered. If that parameter is `null`, all faces not associated with a side are returned (that will never be culled).
 
 Note that this method is called very often: once for every combination of non-culled face and supported block render layer (anywhere between 0 to 28 times) *per block in world*. This method should be as fast as possible, and should probably cache heavily.
 
-The `long` parameter is a random number.
+The `Random` parameter is used for randomised models.
+
+### `getModelData`
+
+This method provides the [`IModelData`][modeldata] instance to the `getQuads` method and has access to the `ILightReader` world, `BlockPos` for the block which is being rendered and the [`IModelData`][modeldata] instance as passed from the `TileEntity`. By default this will pass the [`IModelData`][modeldata] parameter straight to the `getQuads` method but can be used to modify `ModelProperty`'s (see [Model Data][modeldata]). An example use case of this method is to provide the `BlockState` to render for a camouflage block from the neighbouring blocks.
 
 [IModel::bake]: imodel.md#bake
 [Perspective]: perspective.md
 [ItemOverrideList]: itemoverridelist.md
-[extended blockstates]: extended-blockstates.md
+[modeldata]: modeldata.md
 [teisr]: ../../rendering/teisr.md

--- a/docs/models/advanced/ibakedmodel.md
+++ b/docs/models/advanced/ibakedmodel.md
@@ -1,7 +1,7 @@
 `IBakedModel`
 =============
 
-`IBakedModel` is the result of calling [`IModel::bake`][IModel::bake]. Unlike `IModel`, which purely represents a shape without any concept of items or blocks, `IBakedModel` is not as abstract; it represents geometry that has been optimized and reduced to a form where it is (almost) ready to go to the GPU. It can also process the state of an item or block to change the model.
+`IBakedModel` is the result of calling [`IModel#bake`][IModel#bake]. Unlike `IModel`, which purely represents a shape without any concept of items or blocks, `IBakedModel` is not as abstract; it represents geometry that has been optimized and reduced to a form where it is (almost) ready to go to the GPU. It can also process the state of an item or block to change the model.
 
 In a majority of cases, it is not really necessary to implement this interface manually. One can instead use one of the existing implementations.
 
@@ -22,7 +22,7 @@ If the model is being rendered as an item in an inventory, on the ground as an e
 !!! important
     Unless you know what you're doing and are OK with using deprecated features, just `return false` from this and continue on.
 
-When rendering this as an item, returning `true` causes the model to not be rendered, instead falling back to `TileEntityItemStackRenderer::renderItem`. For certain vanilla items such as chests and banners, this method is hardcoded to copy data from the item into a `TileEntity`, before using a `TileEntitySpecialRenderer` to render that TE in place of the item. For all other items, it will use the `TileEntityItemStackRenderer` instance provided by `Item#setTileEntityItemStackRenderer`; refer to [TileEntityItemStackRenderer][teisr] page for more information.
+When rendering this as an item, returning `true` causes the model to not be rendered, instead falling back to `TileEntityItemStackRenderer#renderItem`. For certain vanilla items such as chests and banners, this method is hardcoded to copy data from the item into a `TileEntity`, before using a `TileEntitySpecialRenderer` to render that TE in place of the item. For all other items, it will use the `TileEntityItemStackRenderer` instance provided by `Item#setTileEntityItemStackRenderer`; refer to [TileEntityItemStackRenderer][teisr] page for more information.
 
 ### `getParticleTexture`
 
@@ -38,7 +38,7 @@ See [Perspective][].
 
 ### `getQuads`
 
-This is the main method of `IBakedModel`. It returns `BakedQuad`s, which contain the low-level vertex data that will be used to render the model. If the model is being rendered as a block, then the `IBlockState` passed in is non-null. Additionally, there is a [`IModelData`][modeldata] parameter which contains the data which is passed from the `TileEntity` allowing arbitrary data to be passed from the block to the model. If the model is being rendered as an item, the `ItemOverrideList` returned from `getOverrides` is responsible for handling the state of the item, and the `IBlockState` parameter will be `null`.
+This is the main method of `IBakedModel`. It returns `BakedQuad`s, which contain the low-level vertex data that will be used to render the model. If the model is being rendered as a block, then the `BlockState` passed in is non-null. Additionally, there is a [`IModelData`][modeldata] parameter which contains the data which is passed from the `TileEntity` allowing arbitrary data to be passed from the block to the model. If the model is being rendered as an item, the `ItemOverrideList` returned from `getOverrides` is responsible for handling the state of the item, and the `BlockState` parameter will be `null`.
 
 The `Direction` passed in is used for face culling. If the block against the given side of the block being rendered is opaque, then the faces associated with that side are not rendered. If that parameter is `null`, all faces not associated with a side are returned (that will never be culled).
 
@@ -50,7 +50,7 @@ The `Random` parameter is used for randomised models.
 
 This method provides the [`IModelData`][modeldata] instance to the `getQuads` method and has access to the `ILightReader` world, `BlockPos` for the block which is being rendered and the [`IModelData`][modeldata] instance as passed from the `TileEntity`. By default this will pass the [`IModelData`][modeldata] parameter straight to the `getQuads` method but can be used to modify `ModelProperty`'s (see [Model Data][modeldata]). An example use case of this method is to provide the `BlockState` to render for a camouflage block from the neighbouring blocks.
 
-[IModel::bake]: imodel.md#bake
+[IModel#bake]: imodel.md#bake
 [Perspective]: perspective.md
 [ItemOverrideList]: itemoverridelist.md
 [modeldata]: modeldata.md

--- a/docs/models/advanced/ibakedmodel.md
+++ b/docs/models/advanced/ibakedmodel.md
@@ -22,7 +22,7 @@ If the model is being rendered as an item in an inventory, on the ground as an e
 !!! important
     Unless you know what you're doing and are OK with using deprecated features, just `return false` from this and continue on.
 
-When rendering this as an item, returning `true` causes the model to not be rendered, instead falling back to `TileEntityItemStackRenderer#renderItem`. For certain vanilla items such as chests and banners, this method is hardcoded to copy data from the item into a `TileEntity`, before using a `TileEntitySpecialRenderer` to render that TE in place of the item. For all other items, it will use the `TileEntityItemStackRenderer` instance provided by `Item#setTileEntityItemStackRenderer`; refer to [TileEntityItemStackRenderer][teisr] page for more information.
+When rendering this as an item, returning `true` causes the model to not be rendered, instead falling back to `ItemStackTileEntityRenderer#renderItem`. For certain vanilla items such as chests and banners, this method is hardcoded to copy data from the item into a `TileEntity`, before using a `TileEntitySpecialRenderer` to render that TE in place of the item. For all other items, it will use the `ItemStackTileEntityRenderer` instance provided by `Item#setTileEntityItemStackRenderer`; refer to [ItemStackTileEntityRenderer][teisr] page for more information.
 
 ### `getParticleTexture`
 
@@ -49,6 +49,47 @@ The `Random` parameter is used for randomised models.
 ### `getModelData`
 
 This method provides the [`IModelData`][modeldata] instance to the `getQuads` method and has access to the `ILightReader` world, `BlockPos` for the block which is being rendered and the [`IModelData`][modeldata] instance as passed from the `TileEntity`. By default this will pass the [`IModelData`][modeldata] parameter straight to the `getQuads` method but can be used to modify `ModelProperty`'s (see [Model Data][modeldata]). An example use case of this method is to provide the `BlockState` to render for a camouflage block from the neighbouring blocks.
+
+`BakedQuad`s
+============
+
+The `getQuads` method requires a list of quads to be drawn. These quads can either be generated algorithmically or can be copies of other block models using the `ModelManager`.
+
+!!! note
+When using the quads from another block model, if you are going to manipulate the quads, be sure to copy the quads to not override the quads from the original model.
+
+When constructing the `BakedQuad`s algorithmically, there are several parameters which need to be provided to construct a `BakedQuad` manually however it is often easier to use the `FaceBakery` to generate quads.
+
+### `vertexData`
+
+The vertex data is a structured `int` array providing information about the position of the vertices in the model, the shade color for each vertex and the vertex UV (see `FaceBakery#storeVertexData`). For blocks, each vertex in the quad has **7** float values which are converted into raw integer bits using `Float#floatToRawIntBits` and are as follows (also see `DefaultVertexFormats`):
+1. The x position of the vertex as a float (for a regular JSON model, this is the x position of the vertex divided by 16)
+2. The y position of the vertex formatted the same as with the x position
+3. The z position as above
+4. The shade colour - this uses the hard coded face brightness to apply the correct shading to the side of the quad
+5. The texture U position as a float - this is the position of the texture as a proportion of the width of the `AtlasTexture`
+6. The texture V position as a float - this is the position of the texture as a proportion of the height of the `AtlasTexture`
+7. The vertex normal as an integer (see `ForgeHooksClient#fillNormal`)
+
+### `tintIndex`
+
+The tint index refers to which index to use with `IBlockColor` used to tint this quad. If this quad does not need a tint index, use the tint index `-1`
+
+### `face`
+
+The `Direction` that this quad is normal to. This should be the same face as from the `getQuads` method if the face is not null.
+
+### `sprite`
+
+The `TextureAtlasSprite` that is the texture for this quad
+
+### `applyDiffuseLighting`
+
+Whether to use lighting which depends on the side this quad is facing.
+
+### `format`
+
+The `VertexFormat` object which determines the structure of the `vertexData` parameter. See `DefaultVertexFormats` for all of the vertex format types.
 
 [IModel#bake]: imodel.md#bake
 [Perspective]: perspective.md

--- a/docs/models/advanced/ibakedmodel.md
+++ b/docs/models/advanced/ibakedmodel.md
@@ -56,7 +56,7 @@ This method provides the [`IModelData`][modeldata] instance to the `getQuads` me
 The `getQuads` method requires a list of quads to be drawn. These quads can either be generated algorithmically or can be copies of other block models using the `ModelManager`.
 
 !!! note
-When using the quads from another block model, if you are going to manipulate the quads, be sure to copy the quads to not override the quads from the original model.
+    When using the quads from another block model, if you are going to manipulate the quads, be sure to copy the quads to not override the quads from the original model.
 
 When constructing the `BakedQuad`s algorithmically, there are several parameters which need to be provided to construct a `BakedQuad` manually however it is often easier to use the `FaceBakery` to generate quads.
 

--- a/docs/models/advanced/modeldata.md
+++ b/docs/models/advanced/modeldata.md
@@ -1,0 +1,51 @@
+Model Data
+==========
+
+Model data is the successor of "extended blockstates" allowing modders to pass in extra data to be used in [`IBakedModel::getQuads`][getquads] when rendering blocks. This is particularly useful in complex models such as for camouflage blocks which use other block's models and other dynamic block model related things. This is not to be confused with a [`TileEntityRenderer`][ter] which is used for dynamic rendering such as for animated blocks like a chest or any blocks which cannot be defined by a list of `BakedQuad`s.
+
+IBakedModels vs TERs
+------------------
+
+An [`IBakedModel`][bakedmodel] simply provides a list of `BakedQuad`s to the `BlockModelRenderer` which are then drawn to the screen. There are other properties available which define aspects which effect rendering such as whether the model supports ambient occlusion (a rendering effect). Most [`IBakedModel`][bakedmodel]s come from when a model file is loaded and then "baked" so that the model does not need to be loaded again.
+
+A [`TileEntityRenderer`][ter] or [`TER`][ter] (previously [`TileEntitySpecialRenderer`][ter] or [`TESR`][ter]) is used to render blocks in a way that cannot be represented with a static baked model (JSON, OBJ, B3D, others).
+
+A [`TER`][ter] has direct access to the `TileEntity` that the renderer is used for whereas a [`IBakedModel`][bakedmodel] only has access to the `BlockState` the model represents, the `Direction` which represents the side which is being rendered (or null), an instance of `Random` for randomised textures and the `IModelData` parameter. The [`IBakedModel::getQuads`][getquads] is unaware of where the block is in the world hence where the `IModelData` parameter steps in to provide extra information from the `TileEntity` using `TileEntity::getModelData` and from world using `IBakedModel::getModelData`.
+
+Unlike a [`TER`][ter] which renders every frame, an [`IBakedModel`][bakedmodel] only provides the quads for drawing upon request (which occurs when `World::markBlockRangeForRenderUpdate` is called).
+
+Model Data flow
+------------------------
+
+Model data is first created in the `TileEntity::getModelData` method which by default returns an `EmptyModelData` instance meaning that there is no data provided. This is then passed to the `IBakedModel::getModelData` method as the `tileData` parameter. By default, the `IBakedModel::getModelData` returns the `tileData` parameter. The result of `IBakedModel::getModelData` is then the value of the `modelData` parameter in the [`IBakedModel::getQuads`][getquads] function.
+
+Therefore, in either stage (in the `TileEntity::getModelData` or in the `IBakedModel::getModelData`) we can add or set data.
+
+Constructing Model Data
+-----------------------
+
+Similar to the [blockstate](https://mcforge.readthedocs.io/en/1.14.x/blocks/states/) system, a model data instance consists of multiple `ModelProperty`'s which can be set. In your baked model class, create static final `ModelProperty` instances using the type parameter as the data type you wish to store. The `ModelProperty` constructor also provides an additional predicate which can be used to check the validity of a potential value; however this is set to accept all values by default. Then, to create an `IModelData` instance, we use a `ModelDataMap` builder (`ModelDataMap.Builder`) instance which can setup values that will be present using the `withProperty(<PROPERTY>)` and `withInitial(<PROPERTY>, <VALUE>)` methods which initialise a property with an empty value or with a provided value respectively. Finally, once all properties have been defined, the `build` function should be called to return the `IModelData` instance.
+
+Using Model Data
+----------------
+
+In the [`IBakedModel::getQuads`][getquads] method, the `IModelData` parameter will be that as passed through using the model data flow, and so should contain all the data you provided. Here is a basic example of how data should be retrieved from the `modelData` parameter.
+
+```Java
+@Nonnull
+@Override
+public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, @Nonnull Random rand, @Nonnull IModelData extraData) {
+    if (extraData.hasProperty(PROPERTY)) {
+        String value = extraData.getData(PROPERTY);
+        // TODO do something with this value
+    }
+    return Minecraft.getInstance().getBlockRendererDispatcher().getBlockModelShapes().getModelManager().getMissingModel();
+}
+```
+
+!!! note
+    The data returned from `IModelData::getData` can be null if the property is defined but not initialised / set even if `IModelData::hasProperty` returns `true`.
+
+[bakedmodel]: https://mcforge.readthedocs.io/en/1.14.x/models/advanced/ibakedmodel/
+[getquads]: https://mcforge.readthedocs.io/en/1.14.x/models/advanced/ibakedmodel/#getquads
+[ter]: https://mcforge.readthedocs.io/en/1.14.x/tileentities/tesr/

--- a/docs/models/advanced/modeldata.md
+++ b/docs/models/advanced/modeldata.md
@@ -1,7 +1,7 @@
 Model Data
 ==========
 
-Model data is the successor of "extended blockstates" allowing modders to pass in extra data to be used in [`IBakedModel::getQuads`][getquads] when rendering blocks. This is particularly useful in complex models such as for camouflage blocks which use other block's models and other dynamic block model related things. This is not to be confused with a [`TileEntityRenderer`][ter] which is used for dynamic rendering such as for animated blocks like a chest or any blocks which cannot be defined by a list of `BakedQuad`s.
+Model data is the successor of "extended blockstates" allowing modders to pass in extra data to be used in [`IBakedModel::getQuads`][getquads] when rendering blocks. This is particularly useful in complex models such as for camouflage blocks which use other block's models as an example. This is not to be confused with a [`TileEntityRenderer`][ter] which is used for dynamic rendering such as for animated blocks like a chest or any blocks which cannot be defined by a list of `BakedQuad`s.
 
 IBakedModels vs TERs
 ------------------
@@ -10,35 +10,44 @@ An [`IBakedModel`][bakedmodel] simply provides a list of `BakedQuad`s to the `Bl
 
 A [`TileEntityRenderer`][ter] or [`TER`][ter] (previously [`TileEntitySpecialRenderer`][ter] or [`TESR`][ter]) is used to render blocks in a way that cannot be represented with a static baked model (JSON, OBJ, B3D, others).
 
-A [`TER`][ter] has direct access to the `TileEntity` that the renderer is used for whereas a [`IBakedModel`][bakedmodel] only has access to the `BlockState` the model represents, the `Direction` which represents the side which is being rendered (or null), an instance of `Random` for randomised textures and the `IModelData` parameter. The [`IBakedModel::getQuads`][getquads] is unaware of where the block is in the world hence where the `IModelData` parameter steps in to provide extra information from the `TileEntity` using `TileEntity::getModelData` and from world using `IBakedModel::getModelData`.
+A [`TER`][ter] has direct access to the `TileEntity` that the renderer is used for whereas an [`IBakedModel`][bakedmodel] only has access to the `BlockState` the model represents, the `Direction` which represents the side which is being rendered (or null), an instance of `Random` for randomised textures and the `IModelData` parameter. The [`IBakedModel::getQuads`][getquads] is unaware of where the block is in the world hence where the `IModelData` parameter steps in to provide extra information from the `TileEntity` using `TileEntity::getModelData`, and from the world using `IBakedModel::getModelData`.
 
 Unlike a [`TER`][ter] which renders every frame, an [`IBakedModel`][bakedmodel] only provides the quads for drawing upon request (which occurs when `World::markBlockRangeForRenderUpdate` is called).
 
 Model Data flow
 ------------------------
 
-Model data is first created in the `TileEntity::getModelData` method which by default returns an `EmptyModelData` instance meaning that there is no data provided. This is then passed to the `IBakedModel::getModelData` method as the `tileData` parameter. By default, the `IBakedModel::getModelData` returns the `tileData` parameter. The result of `IBakedModel::getModelData` is then the value of the `modelData` parameter in the [`IBakedModel::getQuads`][getquads] function.
+Model data is first created in the `TileEntity::getModelData` method which by default returns an `EmptyModelData` instance meaning that there is no data provided. This is then passed to the [`IBakedModel::getModelData`][getmodeldata] method as the `tileData` parameter. By default, the [`IBakedModel::getModelData`][getmodeldata] returns the `tileData` parameter. The result of [`IBakedModel::getModelData`][getmodeldata] is then the value of the `modelData` parameter in the [`IBakedModel::getQuads`][getquads] function.
 
-Therefore, in either stage (in the `TileEntity::getModelData` or in the `IBakedModel::getModelData`) we can add or set data.
+Therefore, in either stage (in the `TileEntity::getModelData` or in the [`IBakedModel::getModelData`][getmodeldata]) we can add or set data.
 
 Constructing Model Data
 -----------------------
 
-Similar to the [blockstate](https://mcforge.readthedocs.io/en/1.14.x/blocks/states/) system, a model data instance consists of multiple `ModelProperty`'s which can be set. In your baked model class, create static final `ModelProperty` instances using the type parameter as the data type you wish to store. The `ModelProperty` constructor also provides an additional predicate which can be used to check the validity of a potential value; however this is set to accept all values by default. Then, to create an `IModelData` instance, we use a `ModelDataMap` builder (`ModelDataMap.Builder`) instance which can setup values that will be present using the `withProperty(<PROPERTY>)` and `withInitial(<PROPERTY>, <VALUE>)` methods which initialise a property with an empty value or with a provided value respectively. Finally, once all properties have been defined, the `build` function should be called to return the `IModelData` instance.
+Similar to the [blockstate](https://mcforge.readthedocs.io/en/1.14.x/blocks/states/) system, a model data instance consists of multiple `ModelProperty`'s which are created using a builder. In your baked model class, create static final `ModelProperty` instances using the type parameter as the data type you wish to store (e.g. `ModelProperty<String>()` for a string value). The `ModelProperty` constructor also provides an additional predicate parameter which can be used to check the validity of a potential value; however this is set to accept all values by default. Then, to create an `IModelData` instance, we use a `ModelDataMap` builder (`ModelDataMap.Builder`) instance which can setup values that will be present using the `withProperty(<PROPERTY>)` and `withInitial(<PROPERTY>, <VALUE>)` methods which initialise a property with an empty value or with a provided value respectively. Finally, once all properties have been defined, the `build` function should be called to return the `IModelData` instance.
+
+For example to create an `IModelData` instance with property `PROPERTY` and value `"value"`:
+```Java
+ModelDataMap.Builder().withInitial(PROPERTY, "value").build()
+```
 
 Using Model Data
 ----------------
 
-In the [`IBakedModel::getQuads`][getquads] method, the `IModelData` parameter will be that as passed through using the model data flow, and so should contain all the data you provided. Here is a basic example of how data should be retrieved from the `modelData` parameter.
+In the [`IBakedModel::getQuads`][getquads] method, the `IModelData` parameter will be that as passed through using the model data flow, and so should contain all the data you provided in the `TileEntity::getModelData` and [`IBakedModel::getModelData`][getmodeldata]. Here is a basic example of how data should be retrieved from the `modelData` parameter in the [`IBakedModel::getQuads`][getquads].
 
 ```Java
 @Nonnull
 @Override
 public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, @Nonnull Random rand, @Nonnull IModelData extraData) {
+    // If we have the `PROPERTY` in our data (even if the value is null)
     if (extraData.hasProperty(PROPERTY)) {
+        // Get the data
         String value = extraData.getData(PROPERTY);
         // TODO do something with this value
     }
+
+    // Return the missing texture model
     return Minecraft.getInstance().getBlockRendererDispatcher().getBlockModelShapes().getModelManager().getMissingModel();
 }
 ```
@@ -46,6 +55,7 @@ public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction 
 !!! note
     The data returned from `IModelData::getData` can be null if the property is defined but not initialised / set even if `IModelData::hasProperty` returns `true`.
 
-[bakedmodel]: https://mcforge.readthedocs.io/en/1.14.x/models/advanced/ibakedmodel/
-[getquads]: https://mcforge.readthedocs.io/en/1.14.x/models/advanced/ibakedmodel/#getquads
-[ter]: https://mcforge.readthedocs.io/en/1.14.x/tileentities/tesr/
+[bakedmodel]: ibakedmodel.md
+[getquads]: ibakedmodel.md#getquads
+[getmodeldata]: ibakedmodel.md#getmodeldata
+[ter]: ../../tileentities/tesr.md

--- a/docs/models/advanced/modeldata.md
+++ b/docs/models/advanced/modeldata.md
@@ -1,30 +1,30 @@
 Model Data
 ==========
 
-Model data is the successor of "extended blockstates" allowing modders to pass in extra data to be used in [`IBakedModel::getQuads`][getquads] when rendering blocks. This is particularly useful in complex models such as for camouflage blocks which use other block's models as an example. This is not to be confused with a [`TileEntityRenderer`][ter] which is used for dynamic rendering such as for animated blocks like a chest or any blocks which cannot be defined by a list of `BakedQuad`s.
+Model data is the successor of "extended blockstates" allowing modders to pass in extra data to be used in [`IBakedModel#getQuads`][getquads] when rendering blocks. This is particularly useful in complex models such as for camouflage blocks which use other block's models as an example. This is not to be confused with a [`TileEntityRenderer`][ter] which is used for dynamic rendering such as for animated blocks like a chest or any blocks which cannot be defined by a list of `BakedQuad`s.
 
 IBakedModels vs TERs
 ------------------
 
 An [`IBakedModel`][bakedmodel] simply provides a list of `BakedQuad`s to the `BlockModelRenderer` which are then drawn to the screen. There are other properties available which define aspects which effect rendering such as whether the model supports ambient occlusion (a rendering effect). Most [`IBakedModel`][bakedmodel]s come from when a model file is loaded and then "baked" so that the model does not need to be loaded again.
 
-A [`TileEntityRenderer`][ter] or [`TER`][ter] (previously [`TileEntitySpecialRenderer`][ter] or [`TESR`][ter]) is used to render blocks in a way that cannot be represented with a static baked model (JSON, OBJ, B3D, others).
+A [`TileEntityRenderer`][ter] or [`TER`][ter] (previously [`TileEntitySpecialRenderer`] or [`TESR`]) is used to render blocks in a way that cannot be represented with a static baked model (JSON, OBJ, B3D, others).
 
-A [`TER`][ter] has direct access to the `TileEntity` that the renderer is used for whereas an [`IBakedModel`][bakedmodel] only has access to the `BlockState` the model represents, the `Direction` which represents the side which is being rendered (or null), an instance of `Random` for randomised textures and the `IModelData` parameter. The [`IBakedModel::getQuads`][getquads] is unaware of where the block is in the world hence where the `IModelData` parameter steps in to provide extra information from the `TileEntity` using `TileEntity::getModelData`, and from the world using `IBakedModel::getModelData`.
+A [`TER`][ter] has direct access to the `TileEntity` that the renderer is used for whereas an [`IBakedModel`][bakedmodel] only has access to the `BlockState` the model represents, the `Direction` which represents the side which is being rendered (or null), an instance of `Random` for randomised textures and the `IModelData` parameter. The [`IBakedModel#getQuads`][getquads] is unaware of where the block is in the world hence where the `IModelData` parameter steps in to provide extra information from the `TileEntity` using `TileEntity#getModelData`, and from the world using `IBakedModel#getModelData`.
 
-Unlike a [`TER`][ter] which renders every frame, an [`IBakedModel`][bakedmodel] only provides the quads for drawing upon request (which occurs when `World::markBlockRangeForRenderUpdate` is called).
+Unlike a [`TER`][ter] which renders every frame, an [`IBakedModel`][bakedmodel] only provides the quads for drawing upon request (which occurs when `World#markBlockRangeForRenderUpdate` is called).
 
 Model Data flow
 ------------------------
 
-Model data is first created in the `TileEntity::getModelData` method which by default returns an `EmptyModelData` instance meaning that there is no data provided. This is then passed to the [`IBakedModel::getModelData`][getmodeldata] method as the `tileData` parameter. By default, the [`IBakedModel::getModelData`][getmodeldata] returns the `tileData` parameter. The result of [`IBakedModel::getModelData`][getmodeldata] is then the value of the `modelData` parameter in the [`IBakedModel::getQuads`][getquads] function.
+Model data is first created in the `TileEntity#getModelData` method which by default returns an `EmptyModelData` instance meaning that there is no data provided. This is then passed to the [`IBakedModel#getModelData`][getmodeldata] method as the `tileData` parameter. By default, the [`IBakedModel#getModelData`][getmodeldata] returns the `tileData` parameter. The result of [`IBakedModel#getModelData`][getmodeldata] is then the value of the `modelData` parameter in the [`IBakedModel#getQuads`][getquads] function.
 
-Therefore, in either stage (in the `TileEntity::getModelData` or in the [`IBakedModel::getModelData`][getmodeldata]) we can add or set data.
+Therefore, in either stage (in the `TileEntity#getModelData` or in the [`IBakedModel#getModelData`][getmodeldata]) we can add or set data.
 
 Constructing Model Data
 -----------------------
 
-Similar to the [blockstate](https://mcforge.readthedocs.io/en/1.14.x/blocks/states/) system, a model data instance consists of multiple `ModelProperty`'s which are created using a builder. In your baked model class, create static final `ModelProperty` instances using the type parameter as the data type you wish to store (e.g. `ModelProperty<String>()` for a string value). The `ModelProperty` constructor also provides an additional predicate parameter which can be used to check the validity of a potential value; however this is set to accept all values by default. Then, to create an `IModelData` instance, we use a `ModelDataMap` builder (`ModelDataMap.Builder`) instance which can setup values that will be present using the `withProperty(<PROPERTY>)` and `withInitial(<PROPERTY>, <VALUE>)` methods which initialise a property with an empty value or with a provided value respectively. Finally, once all properties have been defined, the `build` function should be called to return the `IModelData` instance.
+Similar to the [blockstate](../../blocks/states.md) system, a model data instance consists of multiple `ModelProperty`'s which are created using a builder. In your baked model class, create static final `ModelProperty` instances using the type parameter as the data type you wish to store (e.g. `ModelProperty<String>()` for a string value). The `ModelProperty` constructor also provides an additional predicate parameter which can be used to check the validity of a potential value; however this is set to accept all values by default. Then, to create an `IModelData` instance, we use a `ModelDataMap` builder (`ModelDataMap.Builder`) instance which can setup values that will be present using the `withProperty(<PROPERTY>)` and `withInitial(<PROPERTY>, <VALUE>)` methods which initialise a property with an empty value or with a provided value respectively. Finally, once all properties have been defined, the `build` function should be called to return the `IModelData` instance.
 
 For example to create an `IModelData` instance with property `PROPERTY` and value `"value"`:
 ```Java
@@ -34,7 +34,7 @@ ModelDataMap.Builder().withInitial(PROPERTY, "value").build()
 Using Model Data
 ----------------
 
-In the [`IBakedModel::getQuads`][getquads] method, the `IModelData` parameter will be that as passed through using the model data flow, and so should contain all the data you provided in the `TileEntity::getModelData` and [`IBakedModel::getModelData`][getmodeldata]. Here is a basic example of how data should be retrieved from the `modelData` parameter in the [`IBakedModel::getQuads`][getquads].
+In the [`IBakedModel#getQuads`][getquads] method, the `IModelData` parameter will be that as passed through using the model data flow, and so should contain all the data you provided in the `TileEntity#getModelData` and [`IBakedModel#getModelData`][getmodeldata]. Here is a basic example of how data should be retrieved from the `modelData` parameter in the [`IBakedModel#getQuads`][getquads].
 
 ```Java
 @Nonnull
@@ -53,7 +53,7 @@ public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction 
 ```
 
 !!! note
-    The data returned from `IModelData::getData` can be null if the property is defined but not initialised / set even if `IModelData::hasProperty` returns `true`.
+    The data returned from `IModelData#getData` can be null if the property is defined but not initialised / set even if `IModelData#hasProperty` returns `true`.
 
 [bakedmodel]: ibakedmodel.md
 [getquads]: ibakedmodel.md#getquads

--- a/docs/models/advanced/modeldata.md
+++ b/docs/models/advanced/modeldata.md
@@ -1,18 +1,18 @@
 Model Data
 ==========
 
-Model data is the successor of "extended blockstates" allowing modders to pass in extra data to be used in [`IBakedModel#getQuads`][getquads] when rendering blocks. This is particularly useful in complex models such as for camouflage blocks which use other block's models as an example. This is not to be confused with a [`TileEntityRenderer`][ter] which is used for dynamic rendering such as for animated blocks like a chest or any blocks which cannot be defined by a list of `BakedQuad`s.
+Model data is the successor of "extended blockstates" allowing modders to pass in extra data to be used in [`IBakedModel#getQuads`][getquads] when rendering blocks. This is particularly useful in complex models such as for camouflage blocks which use other block's models as an example. This is not to be confused with a [`TileEntityRenderer`][ter] which is used for dynamic rendering such as for animated blocks like a chest or any blocks which cannot be defined by a list of `BakedQuad`s. The [`IBakedModel#getQuads`][getquads] allows modders to algorithmically generate quads or use quads of already defined models.
 
 IBakedModels vs TERs
 ------------------
 
 An [`IBakedModel`][bakedmodel] simply provides a list of `BakedQuad`s to the `BlockModelRenderer` which are then drawn to the screen. There are other properties available which define aspects which effect rendering such as whether the model supports ambient occlusion (a rendering effect). Most [`IBakedModel`][bakedmodel]s come from when a model file is loaded and then "baked" so that the model does not need to be loaded again.
 
-A [`TileEntityRenderer`][ter] or [`TER`][ter] (previously [`TileEntitySpecialRenderer`] or [`TESR`]) is used to render blocks in a way that cannot be represented with a static baked model (JSON, OBJ, B3D, others).
+A [`TileEntityRenderer`][ter] or [`TER`][ter] is used to render blocks in a way that cannot be represented with a static baked model (JSON, OBJ, B3D, others).
 
 A [`TER`][ter] has direct access to the `TileEntity` that the renderer is used for whereas an [`IBakedModel`][bakedmodel] only has access to the `BlockState` the model represents, the `Direction` which represents the side which is being rendered (or null), an instance of `Random` for randomised textures and the `IModelData` parameter. The [`IBakedModel#getQuads`][getquads] is unaware of where the block is in the world hence where the `IModelData` parameter steps in to provide extra information from the `TileEntity` using `TileEntity#getModelData`, and from the world using `IBakedModel#getModelData`.
 
-Unlike a [`TER`][ter] which renders every frame, an [`IBakedModel`][bakedmodel] only provides the quads for drawing upon request (which occurs when `World#markBlockRangeForRenderUpdate` is called).
+Unlike a [`TER`][ter] which renders every frame, an [`IBakedModel`][bakedmodel] only provides the quads for drawing upon request (which occurs when `World#markBlockRangeForRenderUpdate` is called, when the damage block overlay is shown and other cases).
 
 Model Data flow
 ------------------------
@@ -54,6 +54,9 @@ public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction 
 
 !!! note
     The data returned from `IModelData#getData` can be null if the property is defined but not initialised / set even if `IModelData#hasProperty` returns `true`.
+
+!!! warning
+    When [`IBakedModel#getQuads`][getquads] is called for the damage block overlay, the `extraData` parameter is **always** `EmptyModelData.INSTANCE`. The [`IBakedModel#getQuads`][getquads] method is used to get the shape of the model that will be used for the breaking animation and not the texture so in the case where the `extraData` does not contain your `ModelProperty`'s, you should retain the same shape as the model with the `ModelProperty`.
 
 [bakedmodel]: ibakedmodel.md
 [getquads]: ibakedmodel.md#getquads

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
     - Coloring Textures: 'models/color.md'
     - Item Property Overrides: 'models/overrides.md'
     - Advanced Models:
+      - Model Data: 'models/advanced/modeldata.md'
       - IBakedModel: 'models/advanced/ibakedmodel.md'
       - Perspective: 'models/advanced/perspective.md'
       - ItemOverrideList: 'models/advanced/itemoverridelist.md'


### PR DESCRIPTION
I've added some documentation for the new Model Data system which replaces Extended Blockstates in 1.13+.
I've also tweaked the documentation for `IBakedModels` as to include the `getModelData` method.
Hope this is sufficient :)