### PR TITLE
Data generators documentation

### DIFF
--- a/docs/datagen/intro.md
+++ b/docs/datagen/intro.md
@@ -31,6 +31,8 @@ Data Providers
 Data providers are the classes that actually define what data will be generated and provided. All data providers implement `IDataProvider`.
 Minecraft has abstract implementations for most assets and data, so modders need only to extend and override the abstract method.
 
+The `GatherDataEvent` is fired on the mod event bus when the data generator is being created, and the `DataGenerator` can be obtained from the event. Create and register your providers to the `DataGenerator` using `addProvider()`.
+
 ### Client Assets
   * `LanguageProvider` - for language strings
   * `ModelProvider` - base class for all model providers
@@ -47,5 +49,3 @@ Minecraft has abstract implementations for most assets and data, so modders need
 	An `AdvancementProvider` class does exists, however it is hardcoded for only the vanilla advancements.
 	
 	`LootTableProvider` does not provide an abstract method to override, you must override `act()`. 
-
-The `GatherDataEvent` is fired on the mod event bus when the data generator is being created, and the `DataGenerator` can be obtained from the event. Create and register your providers to the `DataGenerator` using `addProvider()`.

--- a/docs/datagen/intro.md
+++ b/docs/datagen/intro.md
@@ -5,7 +5,7 @@ Data generators are a way to programmatically generate the assets and data of yo
 
 The data generator system is loaded by the main class `net.minecraft.data.Main`. Different arguments can be passed to it, to customize which mods' data are gathered, what existing files are considered, etc. The class responsible for data generation is `net.minecraft.data.DataGenerator`.
 
-ForgeGradle provides the `runData` task to run the data generators. The IDE-specific runs generation tasks (`gen***Tasks`) also create run configurations for running the data generator.
+ForgeGradle provides the `runData` task to run the data generators. The IDE-specific runs generation tasks (`genEclipseRuns`, `genIntellijRuns`, `genVSCodeRuns`) also create run configurations for running the data generator.
 
 Generator Modes
 ---------------

--- a/docs/datagen/intro.md
+++ b/docs/datagen/intro.md
@@ -1,11 +1,11 @@
 Data Generators
 ===============
 
-Data generators are a way to programmatically generate the assets and data of your mods. It allows the definition of the contents of these files in your code and the automatic generation of these files, without worrying about the specification of the files.
+Data generators are a way to programmatically generate the assets and data of your mods. It allows the definition of the contents of these files in your code and their automatic generation, without worrying about the specifics.
 
-The data generator system is loaded by the main class `net.minecraft.data.Main`. Different arguments can be passed to it, to customize which mods' data are gathered, what existing files are considered, etc. The class responsible for data generation is `net.minecraft.data.DataGenerator`.
+The data generator system is loaded by the main class `net.minecraft.data.Main`. Different command-line arguments can be passed to customize which mods' data are gathered, what existing files are considered, etc. The class responsible for data generation is `net.minecraft.data.DataGenerator`.
 
-ForgeGradle provides the `runData` task to run the data generators. The IDE-specific runs generation tasks (`genEclipseRuns`, `genIntellijRuns`, `genVSCodeRuns`) also create run configurations for running the data generator.
+The default configurations in the MDK `build.gradle` adds the `runData` task for running the data generators.
 
 Generator Modes
 ---------------
@@ -29,23 +29,23 @@ Data Providers
 --------------
 
 Data providers are the classes that actually define what data will be generated and provided. All data providers implement `IDataProvider`.
-Minecraft has abstract implementations for most assets and data, so modders need only to extend and override the abstract method.
+Minecraft has abstract implementations for most assets and data, so modders need only to extend and override the specified method.
 
-The `GatherDataEvent` is fired on the mod event bus when the data generator is being created, and the `DataGenerator` can be obtained from the event. Create and register your providers to the `DataGenerator` using `addProvider()`.
+The `GatherDataEvent` is fired on the mod event bus when the data generator is being created, and the `DataGenerator` can be obtained from the event. Create and register your providers using `DataGenerator#addProvider`.
 
 ### Client Assets
-  * `LanguageProvider` - for language strings
-  * `ModelProvider` - base class for all model providers
-    * `BlockModelProvider` - for block models
-    * `ItemModelProvider` - for item models
-    * `BlockStateProvider` - for block states and their block and item models
+  * `net.minecraftforge.common.data.LanguageProvider` - for language strings; override `#addTranslations`
+  * `ModelProvider<?>` - base class for all model providers
+    * _These classes are under the `net.minecraftforge.client.model.generators` package_
+    * `ItemModelProvider` - for item models; override `#registerModels`
+    * `BlockStateProvider` - for blockstates and their block and item models; override `#registerStatesAndModels`
+    * `BlockModelProvider` - for block models; override `#registerModels`
 
 ### Server Data
-  * `LootTableProvider` - for loot tables
-  * `RecipeProvider` - for recipes and their unlocking advancements
-  * `TagsProvider` - for tags
+  * _These classes are under the `net.minecraft.data` package_
+  * `LootTableProvider` - for loot tables; override `#getTables`
+  * `RecipeProvider` - for recipes and their unlocking advancements; override `#registerRecipes`
+  * `TagsProvider` - for tags; override `#registerTags`
 
 !!! notes
 	An `AdvancementProvider` class does exists, however it is hardcoded for only the vanilla advancements.
-	
-	`LootTableProvider` does not provide an abstract method to override, you must override `act()`. 

--- a/docs/datagen/intro.md
+++ b/docs/datagen/intro.md
@@ -1,0 +1,53 @@
+Data Generators
+===============
+
+Data generators are a way to programmatically generate the assets and data of your mods. It allows the definition of the contents of these files in your code and the automatic generation of these files, without worrying about the specification of the files.
+
+The data generator system is loaded by the main class `net.minecraft.data.Main`. Different arguments can be passed to it, to customize which mods' data are gathered, what existing files are considered, etc. The class responsible for data generation is `net.minecraft.data.DataGenerator`.
+
+Generator Modes
+---------------
+
+The data generator can be configured to run 4 different data generations, which are configured from the command-line parameters, and can be checked from `GatherDataEvent#include***` methods.
+
+  * __Client Assets__
+  	 * Generates client-only files in `assets`: block/item models, blockstate JSONs, language files, etc.
+    * __`--client`__, `includeClient()`
+  * __Server Data__
+  	 * Generates server-only files in `data`: recipes, advancements, tags, etc.
+    * __`--server`__, `includeServer()`
+  * __Development Tools__
+  	 * Runs some development tools: converting SNBT to NBT and vice-versa, etc.
+    * __`--dev`__, `includeDev()`
+  * __Reports__
+  	 * Dumps all registered blocks, items, commands, etc.
+    * __`--reports`__, `includeReports()`
+
+
+Data Providers
+--------------
+
+Data providers are the classes that actually define what data will be generated and provided. All data providers implement `IDataProvider`.
+Minecraft has abstract implementations for most assets and data, so modders need only to extend and override the abstract method.
+
+### Client Assets
+  * `LanguageProvider` - for language strings
+  * `ModelProvider` - base class for all model providers
+    * `BlockModelProvider` - for block models
+    * `ItemModelProvider` - for item models
+    * `BlockStateProvider` - for block states and their block and item models
+
+### Server Data
+  * `LootTableProvider` - for loot tables
+  * `RecipeProvider` - for recipes and their unlocking advancements
+  * `TagsProvider` - for tags
+
+!!! notes
+	An `AdvancementProvider` class does exists, however it is hardcoded for only the vanilla advancements.
+	
+	`LootTableProvider` does not provide an abstract method to override, you must override `act()`. 
+
+Registering Providers
+------------------------
+
+The `GatherDataEvent` is fired on the mod event bus when the data generator is being created, and the `DataGenerator` can be obtained from the event. Create and register your providers to the `DataGenerator` using `addProvider()`.

--- a/docs/datagen/intro.md
+++ b/docs/datagen/intro.md
@@ -5,6 +5,8 @@ Data generators are a way to programmatically generate the assets and data of yo
 
 The data generator system is loaded by the main class `net.minecraft.data.Main`. Different arguments can be passed to it, to customize which mods' data are gathered, what existing files are considered, etc. The class responsible for data generation is `net.minecraft.data.DataGenerator`.
 
+ForgeGradle provides the `runData` task to run the data generators. The IDE-specific runs generation tasks (`gen***Tasks`) also create run configurations for running the data generator.
+
 Generator Modes
 ---------------
 
@@ -12,17 +14,16 @@ The data generator can be configured to run 4 different data generations, which 
 
   * __Client Assets__
   	 * Generates client-only files in `assets`: block/item models, blockstate JSONs, language files, etc.
-    * __`--client`__, `includeClient()`
+     * __`--client`__, `includeClient()`
   * __Server Data__
   	 * Generates server-only files in `data`: recipes, advancements, tags, etc.
-    * __`--server`__, `includeServer()`
+     * __`--server`__, `includeServer()`
   * __Development Tools__
   	 * Runs some development tools: converting SNBT to NBT and vice-versa, etc.
-    * __`--dev`__, `includeDev()`
+     * __`--dev`__, `includeDev()`
   * __Reports__
   	 * Dumps all registered blocks, items, commands, etc.
-    * __`--reports`__, `includeReports()`
-
+     * __`--reports`__, `includeReports()`
 
 Data Providers
 --------------
@@ -46,8 +47,5 @@ Minecraft has abstract implementations for most assets and data, so modders need
 	An `AdvancementProvider` class does exists, however it is hardcoded for only the vanilla advancements.
 	
 	`LootTableProvider` does not provide an abstract method to override, you must override `act()`. 
-
-Registering Providers
-------------------------
 
 The `GatherDataEvent` is fired on the mod event bus when the data generator is being created, and the `DataGenerator` can be obtained from the event. Create and register your providers to the `DataGenerator` using `addProvider()`.

--- a/docs/datagen/intro.md
+++ b/docs/datagen/intro.md
@@ -1,7 +1,7 @@
 Data Generators
 ===============
 
-Data generators are a way to programmatically generate the assets and data of your mods. It allows the definition of the contents of these files in your code and their automatic generation, without worrying about the specifics.
+Data generators are a way to programmatically generate the assets and data of mods. It allows the definition of the contents of these files in the code and their automatic generation, without worrying about the specifics.
 
 The data generator system is loaded by the main class `net.minecraft.data.Main`. Different command-line arguments can be passed to customize which mods' data are gathered, what existing files are considered, etc. The class responsible for data generation is `net.minecraft.data.DataGenerator`.
 
@@ -31,7 +31,7 @@ Data Providers
 Data providers are the classes that actually define what data will be generated and provided. All data providers implement `IDataProvider`.
 Minecraft has abstract implementations for most assets and data, so modders need only to extend and override the specified method.
 
-The `GatherDataEvent` is fired on the mod event bus when the data generator is being created, and the `DataGenerator` can be obtained from the event. Create and register your providers using `DataGenerator#addProvider`.
+The `GatherDataEvent` is fired on the mod event bus when the data generator is being created, and the `DataGenerator` can be obtained from the event. Create and register data providers using `DataGenerator#addProvider`.
 
 ### Client Assets
   * `net.minecraftforge.common.data.LanguageProvider` - for language strings; override `#addTranslations`

--- a/docs/datagen/modelproviders.md
+++ b/docs/datagen/modelproviders.md
@@ -2,7 +2,7 @@ Model Providers
 ===============
 The model providers are a specific type of data generators for defining models. All model providers are a subclass of `ModelProvider`.
 
-`ModelProvider` provides methods to define models for blocks and items alike: cubes, single textures, doors, slabs, and even your own custom non-data-generated models as parent models.
+`ModelProvider` provides methods to define models for blocks and items alike: cubes, single textures, doors, slabs, and even custom non-data-generated models as parent models.
 
 Existing Files
 --------------

--- a/docs/datagen/modelproviders.md
+++ b/docs/datagen/modelproviders.md
@@ -1,0 +1,24 @@
+Model Providers
+===============
+The model providers are a specific type of data generators for defining models. All model providers are a subclass of `ModelProvider`.
+
+`ModelProvider` provides methods to define models for blocks and items alike: cubes, single textures, doors, slabs, and even your own custom non-data-generated models as parent models.
+
+Existing Files
+--------------
+All references to textures or other data files not generated for data generation must reference existing files on the system. This is to ensure that all referenced textures are in the correct places, so typos can be found and corrected. 
+
+`ExistingFileHelper` is the class responsible for validating the existence of those data files. An instance can be retrieved from  `GatherDataEvent#getExistingFileHelper()`.
+
+The `--existing <folderpath>` argument allows the specified folder and its subfolders to be used when validating the existence of files. By default, only the vanilla datapack and resources are available to the `ExistingFileHelper`.
+
+Implementation
+--------------
+There are three main abstract implementations of `ModelProvider`: `ItemModelProvder`, `BlockModelProvider`, and `BlockStateProvider`.
+
+`ItemModelProvider` is for defining models for items, `BlockModelProvider` is for defining models for blocks.
+To use these, override `#generateModels()` and use the various helper methods to define your models. 
+
+`BlockStateProvider` is for defining blockstates, block models, and their item models. It contains an instance of both `BlockModelProvider` and `ItemModelProvider`, which can be accessed through `#models()` and `#itemModels()`.
+
+Call `#getVariantBuilder(Block)` to get a `VariantBlockStateBuilder` for building a blockstate with different variants. Call `#getMultipartBuilder(Block)` to get a `MultiPartBlockStateBuilder` for building a blockstate using multiparts.

--- a/docs/datagen/modelproviders.md
+++ b/docs/datagen/modelproviders.md
@@ -14,11 +14,11 @@ The `--existing <folderpath>` argument allows the specified folder and its subfo
 
 Implementation
 --------------
-There are three main abstract implementations of `ModelProvider`: `ItemModelProvder`, `BlockModelProvider`, and `BlockStateProvider`.
+There are three main abstract implementations of `ModelProvider`: `ItemModelProvider`, `BlockModelProvider`, and `BlockStateProvider`.
 
-`ItemModelProvider` is for defining models for items, `BlockModelProvider` is for defining models for blocks.
-To use these, override `#generateModels()` and use the various helper methods to define your models. 
+For items, use `ItemModelProvider` to define their models: override `#generateModels` and use the helper methods.
 
-`BlockStateProvider` is for defining blockstates, block models, and their item models. It contains an instance of both `BlockModelProvider` and `ItemModelProvider`, which can be accessed through `#models()` and `#itemModels()`.
+For blocks, it is recommended to use `BlockStateProvider` to define the blockstates, models, and their item models in a single class. It contains an instance of both `BlockModelProvider` and `ItemModelProvider`, which can be accessed through `#models()` and `#itemModels()`.
+`BlockModelProvider` is used to define only block models. 
 
-Call `#getVariantBuilder(Block)` to get a `VariantBlockStateBuilder` for building a blockstate with different variants. Call `#getMultipartBuilder(Block)` to get a `MultiPartBlockStateBuilder` for building a blockstate using multiparts.
+Call `#getVariantBuilder(Block)` to get a `VariantBlockStateBuilder` for building a blockstate with different variants, or `#getMultipartBuilder(Block)` to get a `MultiPartBlockStateBuilder` for building a blockstate using multiparts.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,8 @@ nav:
       - ItemOverrideList: 'models/advanced/itemoverridelist.md'
   - Rendering:
     - ItemStackTileEntityRenderer: 'rendering/ister.md'
+  - Data Generation:
+    - Introduction: 'datagen/intro.md'
   - Events:
     - Basic Usage: 'events/intro.md'
   - Networking:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - ItemStackTileEntityRenderer: 'rendering/ister.md'
   - Data Generation:
     - Introduction: 'datagen/intro.md'
+    - Model Providers: 'datagen/modelproviders.md'
   - Events:
     - Basic Usage: 'events/intro.md'
   - Networking:


### PR DESCRIPTION
Creating documentation on data generators, so an official source of documentation exists (outside of `DataGeneratorTest` and user-made tutorials <sub>_cough_ McJty _cough_</sub>).
~~I've based on the 1.15.x branch, because the release of 1.16.x means the change of 1.14.x from supported to legacy. Will rebase my other pull requests when 1.14.x is officialy unsupported.~~
_Rebased on the 1.14.x branch, as [requested by tterag][1.14order]._

- [X] Basic introduction
- [X] `ModelProvider`-specific docs

Currently, `AdvancementProvider` is inaccessible to modders because of hardcoded vanilla values. I am hoping that [MinecraftForge#6375][advpr] will be merged in the near future, so I can update this before merge.
Haven't looked too much into 1.16, but I am expecting that I will have to make a separate PR for 1.16.x for the data-driven dimensions.

[advpr]: https://github.com/MinecraftForge/MinecraftForge/pull/6735
[1.14order]: https://github.com/MinecraftForge/Documentation/pull/311#issuecomment-660429340