### PR TITLE
Add documentation for Access Transformers

### DIFF
--- a/docs/advanced/accesstransformers.md
+++ b/docs/advanced/accesstransformers.md
@@ -1,0 +1,111 @@
+Access Transformers
+===================
+
+Access Transformers (ATs for short) allows for changing the visibility and `final` flags of classes and their methods and fields. They allow modders to access and modify otherwise `private` members in classes outside their control.
+
+The [specification document][specs] can be viewed on the Minecraft Forge GitHub.
+
+!!! note
+    An access transformer preprocessor is required to compile against access-transformed code. ForgeGradle fulfills this purpose for Forge development.
+
+Adding ATs
+----------
+
+Adding an Access Transformer to your mod project is as simple as adding a single line into your `build.gradle`:
+
+```groovy
+// This block is where your mappings version is also specified
+minecraft {
+    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+}
+```
+
+During development, the AT file can be anywhere specified by the line above. However, when loading in a non-development environment, Forge will only search for the exact path of `META-INF/accesstransformer.cfg` in your JAR file.
+
+Comments
+--------
+
+All text after a `#` until the end of the line will be treated as a comment and will not be parsed.
+
+Access Modifiers
+----------------
+
+Access modifiers specify which member visibility the given target will be transformed to. In decreasing order of visibility:
+
+  * `public` - visible to all classes inside and outside its package
+  * `protected` - visible only to classes inside the package and subclasses
+  * `default` - visible only to classes inside the package
+  * `private` - visible only to inside the class
+
+A special modifier `+f` and `-f` can be appended to the aforementioned modifiers to either add or remove respectively the `final` modifier, which prevents subclassing, method overriding, or field modification when applied.
+
+!!! warning
+    Access transformers can **_never_** make a member less visible; they can only widen visibility. The JVM will throw an `IllegalAccessError` if any compiled code references a method or field which cannot be accessed due to restrictive transformations.
+    
+    Directives only modify the method they directly reference; any overriding methods will _not_ be access-transformed. Therefore, **never** transform any non-`public` or non-`static` method, because any overriding methods might still use the restrictive visibility, which will result in the JVM throwing a `VerifyError`. 
+
+Targets and Directives
+------------------
+
+!!! Information
+    When using Access Transformers on Minecraft classes, the SRG name must be used for fields and methods.
+
+### Classes
+To target classes:
+```
+<access modifier> <fully qualified class name>
+```
+Inner classes are denoted by combining the fully qualified name of the outer class and the name of the inner class with a `$` as separator.
+
+### Fields
+To target fields:
+```
+<access modifier> <fully qualified class name> <field name>
+```
+
+### Methods
+Targeting methods require a special syntax to denote the method parameters and return type:
+```
+<access modifier> <fully qualified class name> <method name>(<parameter types>)<return type>
+```
+
+#### Specifying Types
+
+Also called "descriptors": see the [Java Virtual Machine Specification, SE 8, sections 4.3.2 and 4.3.3][jvmdescriptors] for more technical details.
+
+If the return type is void, or the method has no parameters, then it does not need to be specified.
+
+  * `B` - `byte`, a signed byte
+  * `C` - `char`, a Unicode character code point in UTF-16
+  * `D` - 'double', a double-precision floating-point value
+  * `F` - `float`, a single-precision floating-point value
+  * `I` - `integer`, a 32-bit integer
+  * `J` - `long`, a 64-bit integer
+  * `S` - `short`, a signed short
+  * `Z` - `boolean`, a `true` or `false` value
+  * `[` - references one dimension of an array
+    * Example: `[[S` refers to `short[][]`
+  * `L<class name>;` - references a reference type
+    * Example: `Ljava/lang/String;` refers to `java.lang.String` reference type _(note the use of parentheses)_
+
+Examples
+--------
+
+```
+# Makes public the IScreenFactory class in ScreenManager
+public net.minecraft.client.gui.ScreenManager$IScreenFactory
+
+# Makes protected and removes the final modifier from 'random' in MinecraftServer
+protected-f net.minecraft.server.MinecraftServer field_147146_q #random
+
+# Makes public the 'createNamedService' method in Util,
+# accepting a String and returns an ExecutorService
+public net.minecraft.util.Util func_240979_a_(Ljava/lang/String;)Ljava/util/concurrent/ExecutorService; #createNamedService
+
+# Makes public the 'func_239776_a_' method in UUIDCodec,
+# accepting two longs and returning an int[]
+public net.minecraft.util.UUIDCodec func_239776_a_(JJ)[I #func_239776_a_
+```
+
+[specs]: https://github.com/MinecraftForge/AccessTransformers/blob/master/FMLAT.md
+[jvmdescriptors]: https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.2

--- a/docs/advanced/accesstransformers.md
+++ b/docs/advanced/accesstransformers.md
@@ -1,12 +1,9 @@
 Access Transformers
 ===================
 
-Access Transformers (ATs for short) allows for changing the visibility and `final` flags of classes and their methods and fields. They allow modders to access and modify otherwise `private` members in classes outside their control.
+Access Transformers (ATs for short) allow for widening the visibility and modifying the `final` flags of classes, methods, and fields. They allow modders to access and modify otherwise inaccessible members in classes outside their control.
 
 The [specification document][specs] can be viewed on the Minecraft Forge GitHub.
-
-!!! note
-    An access transformer preprocessor is required to compile against access-transformed code. ForgeGradle fulfills this purpose for Forge development.
 
 Adding ATs
 ----------
@@ -30,7 +27,7 @@ All text after a `#` until the end of the line will be treated as a comment and 
 Access Modifiers
 ----------------
 
-Access modifiers specify which member visibility the given target will be transformed to. In decreasing order of visibility:
+Access modifiers specify to what new member visibility the given target will be transformed to. In decreasing order of visibility:
 
   * `public` - visible to all classes inside and outside its package
   * `protected` - visible only to classes inside the package and subclasses
@@ -40,12 +37,12 @@ Access modifiers specify which member visibility the given target will be transf
 A special modifier `+f` and `-f` can be appended to the aforementioned modifiers to either add or remove respectively the `final` modifier, which prevents subclassing, method overriding, or field modification when applied.
 
 !!! warning
-    Access transformers can **_never_** make a member less visible; they can only widen visibility. The JVM will throw an `IllegalAccessError` if any compiled code references a method or field which cannot be accessed due to restrictive transformations.
+    Directives only modify the method they directly reference; any overriding methods will not be access-transformed. It is advised to ensure transformed methods do not have non-transformed overrides that restrict the visibility, which will result in the JVM throwing an error.
     
-    Directives only modify the method they directly reference; any overriding methods will _not_ be access-transformed. Therefore, **never** transform any non-`public` or non-`static` method, because any overriding methods might still use the restrictive visibility, which will result in the JVM throwing a `VerifyError`. 
+    Examples of methods that can be safely transformed are `private` methods, `final` methods (or methods in `final` classes), and `static` methods.
 
 Targets and Directives
-------------------
+----------------------
 
 !!! Information
     When using Access Transformers on Minecraft classes, the SRG name must be used for fields and methods.
@@ -77,7 +74,7 @@ If the return type is void, or the method has no parameters, then it does not ne
 
   * `B` - `byte`, a signed byte
   * `C` - `char`, a Unicode character code point in UTF-16
-  * `D` - 'double', a double-precision floating-point value
+  * `D` - `double`, a double-precision floating-point value
   * `F` - `float`, a single-precision floating-point value
   * `I` - `integer`, a 32-bit integer
   * `J` - `long`, a 64-bit integer
@@ -86,7 +83,7 @@ If the return type is void, or the method has no parameters, then it does not ne
   * `[` - references one dimension of an array
     * Example: `[[S` refers to `short[][]`
   * `L<class name>;` - references a reference type
-    * Example: `Ljava/lang/String;` refers to `java.lang.String` reference type _(note the use of parentheses)_
+    * Example: `Ljava/lang/String;` refers to `java.lang.String` reference type _(note the use of slashes instead of periods)_
 
 Examples
 --------

--- a/docs/advanced/accesstransformers.md
+++ b/docs/advanced/accesstransformers.md
@@ -17,6 +17,8 @@ minecraft {
 }
 ```
 
+After adding or modifying the Access Transformer, the gradle project must be refreshed for the transformations to take effect.
+
 During development, the AT file can be anywhere specified by the line above. However, when loading in a non-development environment, Forge will only search for the exact path of `META-INF/accesstransformer.cfg` in your JAR file.
 
 Comments

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,8 @@ nav:
     - Versioning: 'conventions/versioning.md'
     - Locations: 'conventions/locations.md'
     - Loading Stages: 'conventions/loadstages.md'
+  - Advanced Topics:
+    - Access Transformers: 'advanced/accesstransformers.md'
   - Contributing to Forge:
     - Getting Started: 'forgedev/index.md'
     - PR Guidelines: 'forgedev/prguidelines.md'


### PR DESCRIPTION
_This PR closes #87._

Adds documentation about Access Transformers. Sources include the [AccessTransformer specification][atspec], the [Java Virtual Machine Specification, SE 8, sections 4.3.2 and 4.3.3][jvmspec], and questions from Discord about [AT paths][atpath] and [AT cautionary advice][atvisibility].

[atspec]: https://github.com/MinecraftForge/AccessTransformers/blob/master/FMLAT.md
[jvmspec]: https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.3.2
[atpath]: https://discordapp.com/channels/313125603924639766/454376090362970122/733757461550596146
[atvisibility]: https://discordapp.com/channels/313125603924639766/454376090362970122/733781382815285289