### PR TITLE
Fix path of example logoFile in mods.toml

### DIFF
--- a/docs/gettingstarted/structuring.md
+++ b/docs/gettingstarted/structuring.md
@@ -37,7 +37,7 @@ The `mods.toml` file is formatted as [TOML](https://github.com/toml-lang/toml), 
       displayName="Example Mod"
       updateJSONURL="minecraftforge.net/versions.json"
       displayURL="minecraftforge.net"
-      logoFile="assets/examplemod/textures/logo.png"
+      logoFile="logo.png"
       credits="I'd like to thank my mother and father."
       authors="Author"
       description='''


### PR DESCRIPTION
Right now, the logoFile line in the example mods.toml on the Structuring page reads `      logoFile="assets/examplemod/textures/logo.png"`. However, later in the page it says the logofile "must be placed in the root resource folder, not in a subfolder." I confirmed that if you put a logofile in the mods.toml with a path, it crashes. So this PR changes the logoFile line in the example mods.toml to read `logoFile="logo.png"`.