### PR TITLE
Improve Contributing Conventions

### DIFF
--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -25,4 +25,10 @@ Titles should be capitalized in the standard titling format. For example,
 
 Essentially, capitalize everything but unimportant words.
 
+Spelling, grammar, and syntax should follow those of American English. Also, prefer using separate words over contractions (e.g. "are not" instead of "aren't").
+
 Please use equals and dash underlines, instead of `#` and `##`. For h3 and lower, `###` etc. is fine. The source of this file contains an example for equals and dash underlining. Equals underlines create h1 text, and dash underlines create h2 text.
+
+When referencing fields and methods outside of code block snippets, they should use a `#` separator (e.g. `ClassName#methodName`). Inner classes should use a `$` separator (e.g. `ClassName$InnerClassName`).
+
+All links should have their location specified at the bottom of the page. Any internal links should reference the page via their relative path.


### PR DESCRIPTION
Addressing [Curle's comment on the omnibus PR](https://github.com/MinecraftForge/Documentation/pull/364#pullrequestreview-688748745), this aims to improve the contributing conventions and standardize some language, grammar, and syntax on the docs.

Conventions
- All language, grammar, and spelling should be in American English
- Prefer separate words over contractions
- References outside of code blocks should use `#` for fields/methods and `$` for inner classes
- Any links should be specified at the bottom of the page with internal links pointing to their relative location.