### PR TITLE
Fix version warning note from RtD

### DIFF
--- a/forge_theme/css/version_warning_fix.css
+++ b/forge_theme/css/version_warning_fix.css
@@ -1,0 +1,15 @@
+/*
+   Fixes the version warning added by ReadTheDocs on non-latest versions to not
+   stretch over the whole side of the screen. Instead, the notice is moved to
+   be above both the sidebar and content, stretched across the width of the
+   screen.
+ */
+
+.sidebar-wrapper {
+  flex-wrap: wrap;
+}
+
+.sidebar-wrapper > .admonition.warning {
+    width: 100%;
+    padding-bottom: 0.5rem;
+}

--- a/forge_theme/css/version_warning_fix.css
+++ b/forge_theme/css/version_warning_fix.css
@@ -10,6 +10,6 @@
 }
 
 .sidebar-wrapper > .admonition.warning {
-    width: 100%;
-    padding-bottom: 0.5rem;
+  width: 100%;
+  padding-bottom: 0.5rem;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,3 +96,6 @@ extra:
   versions:
     1.15.x: 1.15.x
     1.16.x: 1.16.x
+
+extra_css:
+  - css/version_warning_fix.css


### PR DESCRIPTION
Instead of taking up half the screen in width on the left side, it now rests above the sidebar and content and stretched across the screen, retaining prominence but not taking up too much of the screen.

This implements the solution given by @diesieben07 in https://github.com/MinecraftForge/Documentation/issues/370#issuecomment-907755637, slightly modified to reduce the scope of the admonition rule and add a bit of padding to slightly improve the aesthetic of the warning text. _This PR fixes #370._

### Screenshots

_(the HTML of the warning as noted in https://github.com/MinecraftForge/Documentation/issues/370#issuecomment-820033631 is added manually to the page to replicate the issue locally)_

![Screenshot of the implemented fix, in light mode](https://user-images.githubusercontent.com/21304337/131251310-93443b25-b90a-4c8c-9812-0436f8789dac.png)
![Screenshot of the implemented fix, in dark mode](https://user-images.githubusercontent.com/21304337/131251336-7e12d589-2185-4f61-95be-376859fedbaa.png)
