### PR TITLE
Add mention of RetroGradle to the legacy index page

### DIFF
--- a/docs/legacy/index.md
+++ b/docs/legacy/index.md
@@ -7,7 +7,6 @@ Forge has existed for years, and you can still easily access builds of Forge for
 
     These old documentation sites are for reference purposes only. Do not ask for help with old versions on the Forge discord or the Forge forums. **You will not receive support when you are using older versions.**
 
-
 ### List of Previously Documented versions
 
 Unfortunately, not all versions were used for a significant amount of time, and the documentation for that version may be incomplete. Whenever a new version is released, the documentation from the previous version is copied and adjusted over time to include new and updated information. When a version wasn't supported for long, the information was never updated. The accuracy percentages represent how much of the information that should have been updated was actually updated.
@@ -18,3 +17,10 @@ Unfortunately, not all versions were used for a significant amount of time, and 
 |    1.13.x     |    10%     | https://mcforge.readthedocs.io/en/1.13.x/ |
 |    1.14.x     |    10%     | https://mcforge.readthedocs.io/en/1.14.x/ |
 |    1.15.x     |    85%     | https://mcforge.readthedocs.io/en/1.15.x/ |
+
+### RetroGradle
+
+**RetroGradle** is an archival initiative to update the older ForgeGradle 1.x to 2.3 toolchains and their Minecraft versions to use the modern ForgeGradle 4.x and above toolchain. The goal is to preserve all past released versions of Minecraft Forge by moving them to a verifiably working and modern toolchain which is data-driven and not hardcoded for version-specific workflows.
+
+If any developer wishes to contribute to this archival effort, please visit The Forge Project discord server and ask for directions to the designated channel. Please note that this initiative only aims to _preserve_ these old versions for the benefit of the community, _**not** to support developing mods for these old, unsupported versions._ There will not be any support for using or developing for unsupported versions.
+


### PR DESCRIPTION
Also directs developers wishing to contribute to go to the discord and the designated channel therein. As requested by @TheCurle.