### PR TITLE
[1.14.x] Fix version warning note from RtD

### DIFF
--- a/forge_theme/css/version_warning_fix.css
+++ b/forge_theme/css/version_warning_fix.css
@@ -1,0 +1,15 @@
+/*
+   Fixes the version warning added by ReadTheDocs on non-latest versions to not
+   stretch over the whole side of the screen. Instead, the notice is moved to
+   be above both the sidebar and content, stretched across the width of the
+   screen.
+ */
+
+.sidebar-wrapper {
+  flex-wrap: wrap;
+}
+
+.sidebar-wrapper > .admonition.warning {
+  width: 100%;
+  padding-bottom: 0.5rem;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,3 +96,6 @@ extra:
   versions:
     1.14.x: 1.14.x
     1.15.x: 1.15.x
+
+extra_css:
+  - css/version_warning_fix.css


### PR DESCRIPTION
This PR is a backport of #381, a minor CSS fix for the version warning note feature provided by ReadTheDocs.

_Note: This does not imply any sort of support for the contents of the legacy documentation for this version. This is merely to adjust a warning note as to not take up half the screen for those who choose to view the legacy documentation._