### PR TITLE
[1.16.x] Update Sidebar to Display Current Versions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,8 +94,8 @@ theme:
 extra:
   current_version: 1.16.x
   versions:
-    1.15.x: 1.15.x
     1.16.x: 1.16.x
+    1.17.x: 1.17.x
 
 extra_css:
   - css/version_warning_fix.css


### PR DESCRIPTION
Updates the docs sidebar to display the 1.16 and 1.17 versions within the 1.16.x pages.