### PR TITLE
[1.16] Particle Overhaul

### DIFF
--- a/docs/effects/particles.md
+++ b/docs/effects/particles.md
@@ -1,79 +1,123 @@
 Particles
 =========
 
-Terminology
------------
+Particles are an effect within the game used as polish to better improve immersion. Their usefulness also requires great caution because of their methods of creation and reference.
 
-| Term | Description |
-|----------------|----------------|
-| `Particle` | What is responsible for the rendering logic. |
-| `ParticleType<?>` | What is registered using a unique name. |
-| `IParticleData` | What contains server data that needs to be transferred to the client. |
-| `IParticleFactory` | The factory takes in an `IParticleData` and returns a `Particle`. It will be registered using a unique `ParticleType<?>`. |
-
-Different Particles
+Creating a Particle
 -------------------
 
-You will need to have your own implementation of the `Particle` class which will handle the rendering of the particle. Vanilla examples will help you on how to handle rendering. This guide will not get into that and instead only discuss the logic part.
+Particles are broken up between its [**client only**][sides] implementation to display the particle and its common implementation to reference the particle or sync data from the server.
 
-### Sidedness
-The `Particle` class is [**client only**][sides]; it does not exist on the server. This means that creating a fixed parameter particle is somewhat simpler, more on that later. However, if the particle has a parameter with dynamic values, server information is required. For example, breaking blocks create a particle effect based on the broken block's texture. This information obviously depends on the `Blockstate` of the block, which is taken from the server.
+| Class            | Side   | Description |
+| :---             | :---:  |     :---    |
+| ParticleType     | BOTH   | The registry object of a particle's type definition used to reference the particle on either side |
+| IParticleData    | BOTH   | A data holder used to sync information from the network or a command to the associated client(s) |
+| IParticleFactory | CLIENT | A factory registered by the `ParticleType` used to construct a `Particle` from the associated `IParticleData`.
+| Particle         | CLIENT | The renderable logic to display on the associated client(s) |
 
-To make a particle appear, use either `ClientWorld#addParticle`, `ClientWorld#addAlwaysVisibleParticle`, or
-`ServerWorld#sendParticles`. `ServerWorld#addParticle` and `ServerWorld#addAlwaysVisibleParticle` will simply do nothing without throwing any errors.
+### ParticleType
 
-### Does your particle need server data?
-Taking as an example a mod which adds some spells to the game: If there are 8 types of spells added with each one specific color, there is no need for server information. Each spell will have a distinct, registered `ParticleType`. 
-However, if these spells can have modifiers that can affect the color in multiple ways (add/subtract red/green/blue data), then having a registry object for each combination will be tedious. In that case, server information will be required when spawning the particle to calculate the color to use.
+A `ParticleType` is the registry object defining what a particular particle type is and provides an available reference to the specific particle on both sides. As such, every `ParticleType` must be [registered][registration].
 
-ParticleTypes
--------------
+Each `ParticleType` takes in two parameters: an `overrideLimiter` which determines whether the particle renders regardless of distance, and a `IParticleData$IDeserializer` which is used to read the sent `IParticleData` on the client. As the base `ParticleType` is abstract, a single method needs to be implemented: `#codec`. This represents how to encode and decode the associated `IParticleData` of the type.
 
-#### Vanilla Implementation
-While there are a lot of different particles in vanilla, in almost all cases vanilla uses `BasicParticleType`, a basic implementation of `ParticleType` and `IParticleData`. This implementation is used for anything that does not require [server data][servdat]. The only vanilla particles that do not use `BasicParticleType` are redstone dust and block/item texture dependent particles. When requiring server data, a direct implementation of `IParticleData` is needed. 
+!!! note
+  `ParticleType#codec` is only used within the biome codec for vanilla implementations.
 
-The `ParticleTypes` class is very helpful to check out vanilla implementations. Seeing how vanilla implemented each particle will help better evaluate what you need.
-
-#### Registering
-`ParticleType<?>` is a `ForgeRegistryEntry`, so it is [registered normally][registration]. A `ParticleType` needs to be registered for each distinct `Particle`. When using server information, only one `ParticleType` needs to be registered, since it will cover all cases. When opting for covering all discrete cases, multiple `ParticleType`s are registered all using `BasicParticleType`. The difference will come in registering the `IParticleFactory`.
-
-IParticleFactory
-----------------
-
-To tie up everything, you need to implement an `IParticleFactory`. One factory needs to be registered for every `ParticleType` you register. 
-When covering discrete cases, you can specify a parameter in the constructor to be able to differentiate the cases.
-```java
-public static class Factory implements IParticleFactory<BasicParticleType> {
-  private final Color color;
-  public Factory(Color color) {
-    this.color = color;
-  }
-
-  @Nullable
-  @Override
-  public Particle createParticle(BasicParticleType typeIn, World worldIn, double x, double y, double z, double xSpeed, double ySpeed, double zSpeed) {
-    return new SHParticle(worldIn, this.color, x, y, z, xSpeed, ySpeed, zSpeed);
-  }
-}
-```
-In the example above, a `Color` can be specified during registration. The downside is the colors are "hardcoded" and can't be changed using the `/particle` command. However, adding a new distinct case is easy, there only needs to be a new `ParticleType` and the associated factory. Finally, `IParticleFactory` has one method, `#createParticle`, which returns a `Particle`. You can then return a new instance of your particle as shown above. If you are using a `BasicParticleType`, that parameter will be unused.
-
-#### Registering
-Factories need to be added to the `ParticleManager` using the `ParticleFactoryRegisterEvent`. At that point use: `ParticleManager#register` to register your factory. It needs a `ParticleType` (from it, it will get the registry name) and an instance of your `IParticleFactory`. When registering discrete valued particles, the factory will contain the discrete information, like so pertaining to the previous example:
-```java 
-Minecraft.getInstance().particleEngine.register(DeferredRegistration.HEART_CRYSTAL_PARTICLE.get(), new SHParticle.Factory(Color.FIREBRICK));
-Minecraft.getInstance().particleEngine.register(DeferredRegistration.POWER_CRYSTAL_PARTICLE.get(), new SHParticle.Factory(Color.ROYALBLUE));
-```
-The interest in doing this is to avoid having to deal with `IParticleData` and not create multiple `Particle` implementations for each color.
-
-!!! warning
-
-  If you are using an animated sprite set for your `Particle` with its associated JSON, you will need to register an `IParticleMetaFactory` instead. Otherwise, you will throw an `IllegalStateException`.
+In most cases, there is no need to have any particle data sent to the client. For these instances, it is easier to create a new instance of `BasicParticleType`: an implementation of `ParticleType` and `IParticleData` which does not send any custom data to the client besides the type. Most vanilla implementations use `BasicParticleType` besides redstone dust for coloring and block/item dependent particles.
 
 !!! important
+  A `ParticleType` is not needed to make a particle spawn if only referenced on the client. However, it is necessary to use any of the prebuilt logic within `ParticleManager` or spawn a particle from the server.
 
-  `IParticleFactory` is [**client only**][sides], like the `Particle` class. A way of dealing with this is using a handler class and the `EventBusSubscriber` annotation with a dist value.
+### IParticleData
+
+An `IParticleData` represents the data that each particle takes in. It is also used to send data from particles spawned via the server. All particle spawning methods take in a `IParticleData` such that it knows the type of the particle and the data associated with spawning one.
+
+`IParticleData` is broken down into three methods:
+
+| Method         | Description |
+| :---           | :---        |
+| getType        | Gets the type definition of the particle, or the `ParticleType`
+| writeToNetwork | Writes the particle data to a buffer on the server to send to the client
+| writeToString  | Writes the particle data to a string
+
+These objects are either constructed on the fly as needed, or they are singletons as a result of being a `BasicParticleType`.
+
+#### IDeserializer
+
+To receive the `IParticleData` on the client, or to reference the data within a command, the particle data must be deserialized via `IDeserializer`. Each method within `IDeserializer` has a parity encoding method within `IParticleData`:
+
+| Method      | IParticleData Encoder | Description |
+| :---        | :---:                 | :---        |
+| fromCommand | writeToString         | Decodes a particle data from a string, usually from a command. |
+| fromNetwork | writeToNetwork        | Decodes a particle data from a buffer on the client. |
+
+This object, when needing to send custom particle data, is passed into the constructor of the `ParticleType`.
+
+### Particle
+
+A `Particle` provides the rendering logic needed to draw said data onto the screen. To create any `Particle`, two methods must be implemented:
+
+| Method        | Description |
+| :---          | :---        |
+| render        | Renders the particle onto the screen |
+| getRenderType | Gets the render type of the particle |
+
+A common subclass of `Particle` to render textures is `SpriteTexturedParticle`. While `#getRenderType` needs to be implemented, whatever the texture sprite is set will be rendered at the particle's location.
+
+#### IParticleRenderType
+
+`IParticleRenderType` is a variation on `RenderType` which constructs the startup and teardown phase for every particle of that type and then renders them all at once via the `Tessellator`. There are six different render types a particle can be in.
+
+| Render Type                | Description |
+| :---                       | :---        |
+| TERRAIN_SHEET              | Renders a particle whose texture is located within the available blocks |
+| PARTICLE_SHEET_OPAQUE      | Renders a particle whose texture is opaque and located within the available particles |
+| PARTICLE_SHEET_TRANSLUCENT | Renders a particle whose texture is translucent and located within the available particles |
+| PARTICLE_SHEET_LIT         | Same as `PARTICLE_SHEET_OPAQUE`; this renders after all `PARTICLE_SHEET_OPAQUE` particles have been rendered |
+| CUSTOM                     | Provides setup for blending and depth mask but provides no rendering functionality as that would be implemented within `Particle#render` |
+| NO_RENDER                  | The particle will never render |
+
+Implementing a custom render type will be left as an exercise to the reader.
+
+### IParticleFactory
+
+Finally, a particle is usually created via an `IParticleFactory`. A factory has a single method `#createParticle` which is used to create a particle given the particle data, client world, position, and movement delta. Since a `Particle` is not beholden to any particular `ParticleType`, it can be reused in different factories as necessary.
+
+An `IParticleFactory` must be registered by subscribing to the `ParticleFactoryRegisterEvent` on the **mod event bus**. Within the event, the factory can be registered via `ParticleManager#register` by supplying an instance of the factory to the method.
+
+!!! important
+  `ParticleFactoryRegisterEvent` should only be called on the client and thus sided off in some isolated client class, referenced by either `DistExecutor` or `@EventBusSubscriber`.
+
+#### TexturesParticle, IAnimatedSprite, and IParticleMetaFactory
+
+There are three particle render types that cannot use the above method of registration: `PARTICLE_SHEET_OPAQUE`, `PARTICLE_SHEET_TRANSLUCENT`, and `PARTICLE_SHEET_LIT`. This is because all three of these particle render types use a sprite set that is loaded by the `ParticleManager` directly. As such, the textures supplied must be obtained and registered through a different method. This will assume your particle is a subtype of `SpriteTexturedParticle` as that is the only vanilla implementation for this logic.
+
+To add a texture to a particle, a new JSON file must be added to `assets/<modid>/particles`. This is known as the `TexturesParticle`. The name of this file will represent the registry name of the `ParticleType` the factory is being attached to. Each particle JSON is an object. The object stores a single key `textures` which holds an array of `ResourceLocation`s. Any `<modid>:<path>` texture represented here will point to a texture at `assets/<modid>/textures/particle/<path>.png`.
+
+```json5
+{
+  "textures": [
+    // Will point to a texture located in
+    // assets/mymod/textures/particle/particle_texture.png
+    "mymod:particle_texture",
+    // Textures should by ordered by drawing order
+    // e.g. particle_texture will render first, then particle_texture2
+    //      after some time
+    "mymod:particle_texture2"
+  ]
+}
+```
+
+To reference a particle texture, the subtype of `SpriteTexturedParticle` should either take in an `IAnimatedSprite` or a `TextureAtlasSprite` obtained from `IAnimatedSprite`. `IAnimatedSprite` holds a list of textures which refer to the sprites as defined by our `TexturesParticle`. `IAnimatedSprite` has two methods, both of which grab a `TextureAtlasSprite` in different methods. The first method takes in two integers. The backing implementation allows the sprite to have a texture change as it ages. The second method takes in a `Random` instance to get a random texture from the sprite set. The sprite can be set within `SpriteTexturedParticle` by using one of the helper methods that takes in the `IAnimatedSprite`: `#pickSprite` which uses the random method of picking a texture, and `#setSpriteFromAge` which uses the percentage method of two integers to pick the texture.
+
+To register these particle textures, an `IParticleMetaFactory` needs to be supplied to the `ParticleManager#register` method. This method takes in an `IAnimatedSprite` holding the associated sprite set for the particle and creates an `IParticleFactory` to create the particle. The simplest method of implementation can be done by implementing `IParticleFactory` on some class and having the constructor take in an `IAnimatedSprite`. Then the `IAnimatedSprite` can be passed to the particle as normal.
+
+Spawning a Particle
+-------------------
+
+Particles can be spawned from either world instance. However, each side has a specific way to spawn a particle. If on the `ClientWorld`, `#addParticle` can be called to spawn a particle or `#addAlwaysVisibleParticle` can be called to spawn a particle that is visible from any distance. If on the `ServerWorld`, `#sendParticles` can be called to send a packet to the client to spawn the particle. Calling the two `ClientWorld` methods on the server will result in nothing.
 
 [sides]: ../concepts/sides.md
-[servdat]: #does-your-particle-need-server-data
 [registration]: ../concepts/registries.md#registering-things
+[servdat]: #does-your-particle-need-server-data


### PR DESCRIPTION
This PR aims to address the large number of missing information in relation to create a custom particle. Most of the information located in this document only covered a single use case and implementation method when there are quite a number, especially when it comes to differentiating particles with custom particle sprites from particles made from existing resources. This also clarifies some of the misunderstandings relating to particles, specifically what actually gets sent to the client from the server and that `ParticleType`s are not required to spawn a particle.

Closes #358

[Rendered View](https://github.com/ChampionAsh5357/Documentation/blob/particles-1.16/docs/effects/particles.md)