### PR TITLE
Change WorldSavedData to SavedData for 1.18.x

### DIFF
--- a/docs/datastorage/saveddata.md
+++ b/docs/datastorage/saveddata.md
@@ -6,7 +6,7 @@ The Saved Data (SD) system is an alternative to level capabilities that can atta
 Declaration
 -----------
 
-Each SD implementation must subtype the `WorldSavedData` class. There are two important methods to be aware of:
+Each SD implementation must subtype the `SavedData` class. There are two important methods to be aware of:
 
 * `save`: Allows the implementation to write NBT data to the level.
 * `setDirty`: A method that must be called after changing the data, to notify the game that there are changes that need to be written. If not called, `#save` will not get called and the existing data will persist.


### PR DESCRIPTION
If I understand correctly, the class has a new name with the new mappings being used for 1.18.x.