### PR TITLE
Change optional array from deprecated to removed

### DIFF
--- a/docs/utilities/tags.md
+++ b/docs/utilities/tags.md
@@ -26,6 +26,7 @@ Values listed that are not present will cause the tag to error unless the value 
 ```
 
 See the [Vanilla wiki][tags] for a description of the base syntax.
+
 There is also a Forge extension on the Vanilla syntax.
 You may declare a `remove` array of the same format as the `values` array. Any values listed here will be removed from the tag. This acts as a finer grained version of the Vanilla `replace` option.
 

--- a/docs/utilities/tags.md
+++ b/docs/utilities/tags.md
@@ -26,7 +26,8 @@ Values listed that are not present will cause the tag to error unless the value 
 ```
 
 See the [Vanilla wiki][tags] for a description of the base syntax.
-There is also a Forge extension on the Vanilla syntax. You may declare a `remove` array of the same format as the `values` array. Any values listed here will be removed from the tag. This acts as a finer grained version of the Vanilla `replace` option.
+There is also a Forge extension on the Vanilla syntax.
+You may declare a `remove` array of the same format as the `values` array. Any values listed here will be removed from the tag. This acts as a finer grained version of the Vanilla `replace` option.
 
 
 Using Tags In Code

--- a/docs/utilities/tags.md
+++ b/docs/utilities/tags.md
@@ -9,7 +9,7 @@ Tags are declared in your mod's [datapack][datapack]. For example, `/data/<modid
 Similarly, you may append to or override tags declared in other domains, such as Vanilla, by declaring your own JSONs.
 For example, to add your own mod's saplings to the Vanilla sapling tag, you would specify it in `/data/minecraft/tags/blocks/saplings.json`, and Vanilla will merge everything into one tag at reload, if the `replace` option is false.
 If `replace` is true, then all entries before the json specifying `replace` will be removed.
-Values listed that are not present will cause the tag to error unless the value is listed using an id string and required boolean set to false as in the following example.
+Values listed that are not present will cause the tag to error unless the value is listed using an `id` string and `required` boolean set to false as in the following example.
 
 As an example:
 ```json

--- a/docs/utilities/tags.md
+++ b/docs/utilities/tags.md
@@ -11,10 +11,9 @@ For example, to add your own mod's saplings to the Vanilla sapling tag, you woul
 If `replace` is true, then all entries before the json specifying `replace` will be removed.
 See the [Vanilla wiki][tags] for a description of the base syntax.
 
-Forge provides two extensions on the Vanilla syntax:
+Forge extensions on the Vanilla syntax:
 
-* You may declare an `optional` array of the same format as the `values` array, but any values listed here that are not present will not cause the tag loading to error.
-This has been deprecated in favor of the vanilla method of specifying optional tag values.
+* The `optional` array was depreciated and has been removed in favor of the vanilla method of specifying optional tag values.
 * You may declare a `remove` array of the same format as the `values` array. Any values listed here will be removed from the tag. This acts as a finer grained version of the Vanilla `replace` option.
 
 

--- a/docs/utilities/tags.md
+++ b/docs/utilities/tags.md
@@ -9,11 +9,11 @@ Tags are declared in your mod's [datapack][datapack]. For example, `/data/<modid
 Similarly, you may append to or override tags declared in other domains, such as Vanilla, by declaring your own JSONs.
 For example, to add your own mod's saplings to the Vanilla sapling tag, you would specify it in `/data/minecraft/tags/blocks/saplings.json`, and Vanilla will merge everything into one tag at reload, if the `replace` option is false.
 If `replace` is true, then all entries before the json specifying `replace` will be removed.
+Entries which may not be present, such as resources from other mods, can be included using a compound tag that uses an id string and required boolean set to false.
 See the [Vanilla wiki][tags] for a description of the base syntax.
 
-Forge extensions on the Vanilla syntax:
+Forge extension on the Vanilla syntax:
 
-* The `optional` array was depreciated and has been removed in favor of the vanilla method of specifying optional tag values.
 * You may declare a `remove` array of the same format as the `values` array. Any values listed here will be removed from the tag. This acts as a finer grained version of the Vanilla `replace` option.
 
 

--- a/docs/utilities/tags.md
+++ b/docs/utilities/tags.md
@@ -9,12 +9,22 @@ Tags are declared in your mod's [datapack][datapack]. For example, `/data/<modid
 Similarly, you may append to or override tags declared in other domains, such as Vanilla, by declaring your own JSONs.
 For example, to add your own mod's saplings to the Vanilla sapling tag, you would specify it in `/data/minecraft/tags/blocks/saplings.json`, and Vanilla will merge everything into one tag at reload, if the `replace` option is false.
 If `replace` is true, then all entries before the json specifying `replace` will be removed.
-Entries which may not be present, such as resources from other mods, can be included using a compound tag that uses an id string and required boolean set to false.
+Values listed that are not present will cause the tag to error unless the value is listed using an id string and required boolean set to false as in the following example.
+
+As an example:
+```json
+{ "replace": false,
+  "values": [
+    "minecraft:gold_ingot",
+    "mymod:my_ingot",
+    { "id": "othermod:ingot_other", "required": false }
+  ]
+}
+```
+
 See the [Vanilla wiki][tags] for a description of the base syntax.
-
-Forge extension on the Vanilla syntax:
-
-* You may declare a `remove` array of the same format as the `values` array. Any values listed here will be removed from the tag. This acts as a finer grained version of the Vanilla `replace` option.
+  
+There is also a Forge extension on the Vanilla syntax.  You may declare a `remove` array of the same format as the `values` array. Any values listed here will be removed from the tag. This acts as a finer grained version of the Vanilla `replace` option.
 
 
 Using Tags In Code

--- a/docs/utilities/tags.md
+++ b/docs/utilities/tags.md
@@ -9,22 +9,24 @@ Tags are declared in your mod's [datapack][datapack]. For example, `/data/<modid
 Similarly, you may append to or override tags declared in other domains, such as Vanilla, by declaring your own JSONs.
 For example, to add your own mod's saplings to the Vanilla sapling tag, you would specify it in `/data/minecraft/tags/blocks/saplings.json`, and Vanilla will merge everything into one tag at reload, if the `replace` option is false.
 If `replace` is true, then all entries before the json specifying `replace` will be removed.
-Values listed that are not present will cause the tag to error unless the value is listed using an `id` string and `required` boolean set to false as in the following example.
+Values listed that are not present will cause the tag to error unless the value is listed using an `id` string and `required` boolean set to false, as in the following example:
 
-As an example:
 ```json
-{ "replace": false,
+{
+  "replace": false,
   "values": [
     "minecraft:gold_ingot",
     "mymod:my_ingot",
-    { "id": "othermod:ingot_other", "required": false }
+    {
+      "id": "othermod:ingot_other",
+      "required": false
+    }
   ]
 }
 ```
 
 See the [Vanilla wiki][tags] for a description of the base syntax.
-  
-There is also a Forge extension on the Vanilla syntax.  You may declare a `remove` array of the same format as the `values` array. Any values listed here will be removed from the tag. This acts as a finer grained version of the Vanilla `replace` option.
+There is also a Forge extension on the Vanilla syntax. You may declare a `remove` array of the same format as the `values` array. Any values listed here will be removed from the tag. This acts as a finer grained version of the Vanilla `replace` option.
 
 
 Using Tags In Code


### PR DESCRIPTION
Change the description of the `optional` array to state it has been removed as https://github.com/MinecraftForge/MinecraftForge/blob/1.18.x/patches/minecraft/net/minecraft/tags/Tag.java.patch no longer supports it.  Leave the reference to it in the doc to direct users to the vanilla method.