### PR TITLE
Add info for registering to vanilla registries

### DIFF
--- a/docs/concepts/registries.md
+++ b/docs/concepts/registries.md
@@ -47,10 +47,11 @@ public void registerBlocks(RegistryEvent.Register<Block> event) {
 
 Due to some peculiarities of vanilla code, not all registries are wrapped by Forge. These can be static registries, like `RecipeType`, which are safe to use. There are also dynamic registries, like `ConfiguredFeature` and some other worldgen registries, which are typically represented in JSON. These objects should only be registered this way if there is another registry object that requires it. 
 
-Without the benefit of registry objects, we have to be careful of when we do the registration and how.
+Without the benefit of registry objects, care has to be taken to not register things before they're ready. `Lazy` is a utility class that stores a value that is calculated the first time it is accessed. Using `Lazy.of(...)` with a supplier as a parameter is its typical usage. `Lazy` is a subclass of `Supplier`, so `Supplier#get` is used to retrieve the value.
 
-Outside your main mod class, have a static field store a `Lazy` of a call to `Registry#register` containing the object you want to register. Later, in FMLCommonSetupEvent, enqueue a call to `Supplier#get` on the object, thus populating it.
+In this case, the value to be stored is `() -> Registry.register(...)`. For parameters, `Registry#register` takes the registry being added to, a `ResourceLocation` identifying the object to be registered, and the object itself.
 
+The appropriate time to populate these objects is in `FMLCommonSetupEvent`. Because vanilla registries are not guaranteed to be threadsafe, a call to `Supplier#get` should be inside a `ParallelDispatchEvent#enqueueWork` call. This evaluates the `Registry#register` call, which will register the object and allow it to be referenced freely.
 
 !!! note
     Some classes cannot by themselves be registered. Instead, `*Type` classes are registered, and used in the formers' constructors. For example, [`BlockEntity`][blockentity] has `BlockEntityType`, and `Entity` has `EntityType`. These `*Type` classes are factories that simply create the containing type on demand. 


### PR DESCRIPTION
I see this question come up relatively often in the discord, and the errors produced aren't always instructive for what you need to do. There are quite a few registries that are not forge registries so it's useful to have something to point people to.

Some big examples of this are recipe types, placement modifier types, configured and placed features, and block predicates.