### PR TITLE
[1.18.x] Add Admonition Convention

### DIFF
--- a/docs/advanced/accesstransformers.md
+++ b/docs/advanced/accesstransformers.md
@@ -46,7 +46,7 @@ A special modifier `+f` and `-f` can be appended to the aforementioned modifiers
 Targets and Directives
 ----------------------
 
-!!! Information
+!!! important
     When using Access Transformers on Minecraft classes, the SRG name must be used for fields and methods.
 
 ### Classes

--- a/docs/blockentities/blockentity.md
+++ b/docs/blockentities/blockentity.md
@@ -43,12 +43,11 @@ These methods are called whenever the `LevelChunk` containing the `BlockEntity` 
 Use them to read and write to the fields in your block entity class.
 
 !!! note
-
 		Whenever your data changes, you need to call `BlockEntity#setChanged`; otherwise, the `LevelChunk` containing your `BlockEntity` might be skipped while the level is saved.
 
 !!! important
-
 		It is important that you call the `super` methods!
+
     The tag names `id`, `x`, `y`, `z`, `ForgeData` and `ForgeCaps` are reserved by the `super` methods.
 
 ## Ticking `BlockEntities`
@@ -70,9 +69,7 @@ public static void tick(Level level, BlockPos pos, BlockState state, T blockEnti
 ```
 
 !!! note
-    This method is called each tick; therefore, you should avoid having complicated calculations in here.
-    If possible, you should make more complex calculations every X ticks.
-    (The amount of ticks in a second may be lower then 20 (twenty) but won't be higher)
+    This method is called each tick; therefore, you should avoid having complicated calculations in here. If possible, you should make more complex calculations every X ticks. (The amount of ticks in a second may be lower then 20 (twenty) but won't be higher)
 
 ## Synchronizing the Data to the Client
 
@@ -90,7 +87,6 @@ Again, this is pretty simple, the first method collects the data that should be 
 while the second one processes that data. If your `BlockEntity` doesn't contain much data, you might be able to use the methods out of the [Storing Data within your `BlockEntity`][storing-data] section.
 
 !!! important
-
     Synchronizing excessive/useless data for block entities can lead to network congestion. You should optimize your network usage by sending only the information the client needs when the client needs it. For instance, it is more often than not unnecessary to send the inventory of a block entity in the update tag, as this can be synchronized via its `AbstractContainerMenu`.
 
 ### Synchronizing on Block Update
@@ -134,9 +130,7 @@ You should first check out the [`Networking`][networking] section and especially
 Once you've created your custom network message, you can send it to all users that have the `BlockEntity` loaded with `SimpleChannel#send(PacketDistributor$PacketTarget, MSG)`.
 
 !!! warning
-
-    It is important that you do safety checks, the `BlockEntity` might already be destroyed/replaced when the message arrives at the player!
-    You should also check if the chunk is loaded (`Level#hasChunkAt(BlockPos)`).
+    It is important that you do safety checks, the `BlockEntity` might already be destroyed/replaced when the message arrives at the player! You should also check if the chunk is loaded (`Level#hasChunkAt(BlockPos)`).
 
 [registration]: ../concepts/registries.md#methods-for-registering
 [storing-data]: #storing-data-within-your-blockentity

--- a/docs/blocks/blocks.md
+++ b/docs/blocks/blocks.md
@@ -17,8 +17,7 @@ For simple blocks, which need no special functionality (think cobblestone, woode
 
 All these methods are *chainable* which means you can call them in series. See the `Blocks` class for examples of this.
 
-!!! Note
-
+!!! note
     Blocks have no setter for their `CreativeModeTab`. This has been moved to the `BlockItem` and is now its responsibility. Furthermore, there is no setter for translation key as it is now generated from the registry name.
 
 ### Advanced Blocks
@@ -31,7 +30,6 @@ Registering a Block
 Blocks must be [registered][registering] to function.
 
 !!! important
-
     A block in the level and a "block" in an inventory are very different things. A block in the level is represented by an `BlockState`, and its behavior defined by an instance of `Block`. Meanwhile, an item in an inventory is an `ItemStack`, controlled by an `Item`. As a bridge between the different worlds of `Block` and `Item`, there exists the class `BlockItem`. `BlockItem` is a subclass of `Item` that has a field `block` that holds a reference to the `Block` it represents. `BlockItem` defines some of the behavior of a "block" as an item, like how a right click places the block. It's possible to have a `Block` without an `BlockItem`. (E.g. `minecraft:water` exists a block, but not an item. It is therefore impossible to hold it in an inventory as one.)
 
     When a block is registered, *only* a block is registered. The block does not automatically have an `BlockItem`. To create a basic `BlockItem` for a block, one should set the registry name of the `BlockItem` to that of its `Block`. Custom subclasses of `BlockItem` may be used as well. Once an `BlockItem` has been registered for a block, `Block#asItem` can be used to retrieve it. `Block#asItem` will return `Items#AIR` if there is no `BlockItem` for the `Block`, so if you are not certain that there is an `BlockItem` for the `Block` you are using, check for if `Block#asItem` returns `Items#AIR`.

--- a/docs/blocks/interaction.md
+++ b/docs/blocks/interaction.md
@@ -92,10 +92,8 @@ public void attack(BlockState state, Level level, BlockPos pos, Player player)
 
 Called on a block when it is clicked by a player.
 
-!!! Note
-    
-    This method is for when the player *left-clicks* on a block.
-    Don't get this confused with `use`, which is called when the player *right-clicks*.
+!!! note
+    This method is for when the player *left-clicks* on a block. Don't get this confused with `use`, which is called when the player *right-clicks*.
 
 ### Parameters:
 |      Type       |     Name     |                  Description                  |

--- a/docs/blocks/states.md
+++ b/docs/blocks/states.md
@@ -38,7 +38,7 @@ The `BlockState` system is a flexible and powerful system, but it also has limit
 
 Not all blocks and situations require the usage of `BlockState`; only the most basic properties of a block should be put into a `BlockState`, and any other situation is better off with having a `BlockEntity` or being a separate `Block`. Always consider if you actually need to use blockstates for your purposes.
 
-!!! Note
+!!! note
     A good rule of thumb is: **if it has a different name, it should be a separate block**.
 
 An example is making chair blocks: the *direction* of the chair should be a *property*, while the different *types of wood* should be separated into different blocks.

--- a/docs/concepts/registries.md
+++ b/docs/concepts/registries.md
@@ -211,8 +211,7 @@ When using `RegistryEvent$NewRegistry`, all one needs to do is construct the reg
 The `DeferredRegister` method is once again another wrapper around the above event. Once a `DeferredRegister` is created in a constant field, the registry can be constructed via `DeferredRegister#makeRegistry`. This takes in the name of the registry along with a supplied `RegistryBuilder` containing any additional configurations. The method already populates `#setName` and `#setType` by default. Since this method can be returned at any time, a supplied version of an `IForgeRegistry` is returned instead. This will be unresolvable until `RegistryEvent$NewRegistry` passes.
 
 !!! important
-
-  `DeferredRegister#makeRegistry` must be called before the `DeferredRegister` is added to the mod event bus via `#register`. `#makeRegistry` also uses the `#register` method to create the registry during `RegistryEvent$NewRegistry`.
+    `DeferredRegister#makeRegistry` must be called before the `DeferredRegister` is added to the mod event bus via `#register`. `#makeRegistry` also uses the `#register` method to create the registry during `RegistryEvent$NewRegistry`.
 
 Handling Missing Entries
 ------------------------

--- a/docs/concepts/sides.md
+++ b/docs/concepts/sides.md
@@ -35,7 +35,6 @@ Considering the use of a single "universal" jar for client and server mods, and 
 How do we resolve this? Luckily, FML has `DistExecutor`, which provides various methods to run different methods on different physical sides, or a single method only on one side.
 
 !!! note
-
     It is important to understand that FML checks based on the **physical** side. A single player world (logical server + logical client within a physical client) will always use `Dist.CLIENT`!
 
 `DistExecutor` works by taking in a supplied supplier executing a method, effectively preventing classloading by taking advantage of the [`invokedynamic` JVM instruction][invokedynamic]. The executed method should be static and within a different class. Additionally, if no parameters are present for the static method, a method reference should be used instead of a supplier executing a method.
@@ -62,7 +61,6 @@ DistExecutor.safeCallWhenOn(Dist.CLIENT, () -> ExampleClass::safeCallMethodExamp
 ```
 
 !!! warning
-
     Due to a change in how `invokedynamic` works in Java 9+, all `#safe*` variants of the `DistExecutor` methods throw the original exception wrapped within a `BootstrapMethodError` in the development environment. `#unsafe*` variants or a check to [`FMLEnvironment#dist`][dist] should be used instead.
 
 ### Thread Groups

--- a/docs/conventions/loadstages.md
+++ b/docs/conventions/loadstages.md
@@ -18,6 +18,7 @@ public class MyMod {
 !!! warning
     All four of the below events are called for all mods in parallel, meaning they are all a subclass of `ParallelDispatchEvent`. That is, all mods will concurrently receive common setup, FML will wait for 
     them all to finish, then all mods will concurrently receive sided setup, and so forth.
+    
     Mods *must* take care to be thread safe, especially when calling other mods' APIs and accessing Vanilla systems, which are not thread safe in general. This can be done by calling `#enqueueWork` on the event parameter.
 
 

--- a/docs/datastorage/capabilities.md
+++ b/docs/datastorage/capabilities.md
@@ -32,8 +32,7 @@ static Capability<IItemHandler> ITEM_HANDLER_CAPABILITY = CapabilityManager.get(
 When called, `CapabilityManager#get` provides a non-null capability for your associated type. The anonymous `CapabilityToken` allows Forge to keep a soft dependency system while still having the necessary generic information to get the correct capability.
 
 !!! important
-
-  Even if you have a non-null capability available to you at all times, it does not mean the capability itself is usable or registered yet. This can be checked via `Capability#isRegistered`.
+    Even if you have a non-null capability available to you at all times, it does not mean the capability itself is usable or registered yet. This can be checked via `Capability#isRegistered`.
 
 The `#getCapability` method has a second parameter, of type `Direction`, which can be used to request the specific instance for that one face. If passed `null`, it can be assumed that the request comes either from within the block or from some place where the side has no meaning, such as a different dimension. In this case a general capability instance that does not care about sides will be requested instead. The return type of `#getCapability` will correspond to a `LazyOptional` of the type declared in the capability passed to the method. For the Item Handler capability, this is `LazyOptional<IItemHandler>`. If the capability is not available for a particular provider, it will return an empty `LazyOptional` instead.
 

--- a/docs/effects/particles.md
+++ b/docs/effects/particles.md
@@ -22,12 +22,12 @@ A `ParticleType` is the registry object defining what a particular particle type
 Each `ParticleType` takes in two parameters: an `overrideLimiter` which determines whether the particle renders regardless of distance, and a `ParticleOptions$Deserializer` which is used to read the sent `ParticleOptions` on the client. As the base `ParticleType` is abstract, a single method needs to be implemented: `#codec`. This represents how to encode and decode the associated `ParticleOptions` of the type.
 
 !!! note
-  `ParticleType#codec` is only used within the biome codec for vanilla implementations.
+    `ParticleType#codec` is only used within the biome codec for vanilla implementations.
 
 In most cases, there is no need to have any particle data sent to the client. For these instances, it is easier to create a new instance of `SimpleParticleType`: an implementation of `ParticleType` and `ParticleOptions` which does not send any custom data to the client besides the type. Most vanilla implementations use `SimpleParticleType` besides redstone dust for coloring and block/item dependent particles.
 
 !!! important
-  A `ParticleType` is not needed to make a particle spawn if only referenced on the client. However, it is necessary to use any of the prebuilt logic within `ParticleEngine` or spawn a particle from the server.
+    A `ParticleType` is not needed to make a particle spawn if only referenced on the client. However, it is necessary to use any of the prebuilt logic within `ParticleEngine` or spawn a particle from the server.
 
 ### ParticleOptions
 
@@ -87,7 +87,7 @@ Finally, a particle is usually created via an `ParticleProvider`. A factory has 
 An `ParticleProvider` must be registered by subscribing to the `ParticleFactoryRegisterEvent` on the **mod event bus**. Within the event, the factory can be registered via `ParticleEngine#register` by supplying an instance of the factory to the method.
 
 !!! important
-  `ParticleFactoryRegisterEvent` should only be called on the client and thus sided off in some isolated client class, referenced by either `DistExecutor` or `@EventBusSubscriber`.
+    `ParticleFactoryRegisterEvent` should only be called on the client and thus sided off in some isolated client class, referenced by either `DistExecutor` or `@EventBusSubscriber`.
 
 #### ParticleDescription, SpriteSet, and SpriteParticleRegistration
 

--- a/docs/forgedev/index.md
+++ b/docs/forgedev/index.md
@@ -10,7 +10,7 @@ Like most major open source projects you will find, Forge is hosted on [GitHub][
 
 For those who are beginners when it comes to collaboration via Git, here are two easy steps to get you started.
 
-!!! Note
+!!! note
     This guide assumes that you already have a GitHub account set up. If you do not, visit their [registration page][register] to create an account. Furthermore, this guide is not a tutorial for git's usage. Please consult different sources first if you are struggling to get it working.
 
 ### Forking
@@ -114,7 +114,7 @@ You might want to test changes in Forge with an existing project. The [video][te
  7. In the window that just opened, select the `Forge_main` module.
  8. From here on, reproduce the steps from the test mods section, just with your project's `_main` module instead of the `Forge_test` one.
 
-!!! Note
+!!! note
     You might need to remove existing dependencies from a normal development environment (mainly references to a `forgeSrc` JAR) or move the Forge module higher up in the dependency list.
 
 You should now be able to work with your mod using the changes you introduce to the Forge and Vanilla codebase.
@@ -136,7 +136,7 @@ To initiate the patch generation, simply run the `genPatches` Gradle task from y
 
 The last step before your contribution is added to Forge is a Pull Request (PR in short). This is a formal request to incorporate your fork's changes into the live code base. Creating a PR is easy. Simply go to [this GitHub page][submitpr] and follow the proposed steps. It is now that a good setup with branches pays off, since you are able to select precisely the changes you want to submit.
 
-!!! Note
+!!! note
     Pull Requests are bound to rules; not every request will blindly be accepted. Follow [this document][contribute] to get further information and to ensure the best quality of your PR! If you want to maximize the chances of your PR getting accepted, follow these [PR guidelines][guidelines]!
 
 [github]: https://www.github.com

--- a/docs/gettingstarted/debugprofiler.md
+++ b/docs/gettingstarted/debugprofiler.md
@@ -7,7 +7,7 @@ Minecraft provides a Debug Profiler that provides system data, current game sett
 The Debug Profiler is very simple to use. It requires the debug keybind `F3 + L` to start the profiler. After 10 seconds, it will automatically stop; however, it can be stopped earlier by pressing the keybind again.
 
 !!! note
-  Naturally, you can only profile code paths that are actually being reached. `Entities` and `BlockEntities` that you want to profile must exist in the level to show up in the results.
+    Naturally, you can only profile code paths that are actually being reached. `Entities` and `BlockEntities` that you want to profile must exist in the level to show up in the results.
 
 After you have stopped the debugger, it will create a new zip within the `debug/profiling` subdirectory in your run directory.
 The file name will be formatted with the date and time as `yyyy-mm-dd_hh_mi_ss-WorldName-VersionNumber.zip`

--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -29,7 +29,6 @@ Customizing Your Mod Information
 Edit the `build.gradle` file to customize how your mod is built (the file names, versions, and other things).
 
 !!! important
-
     **Do not** edit the `buildscript {}` section of the build.gradle file, its default text is necessary for ForgeGradle to function.
 
 Almost anything underneath the `// Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.` marker can be changed. Many things can be removed and customized there as well.
@@ -56,7 +55,6 @@ Building and Testing Your Mod
 3. You can also run a dedicated server using the server run config or via `gradlew runServer`. This will launch the Minecraft server with its GUI. After the first run, the server will shut down immediately until the Minecraft EULA is accepted by editing `run/eula.txt`. Once accepted, the server will load and can be accessed via a direct connect to `localhost`.
 
 !!! note
-
     It is always advisable to test your mod in a dedicated server environment if it is intended to run there.
     
 [files]: https://files.minecraftforge.net "Forge Files distribution site"

--- a/docs/gettingstarted/structuring.md
+++ b/docs/gettingstarted/structuring.md
@@ -9,7 +9,6 @@ Packaging
 Pick a unique package name. If you own a URL associated with your project, you can use it as your top level package. For example if you own "example.com", you may use `com.example` as your top level package.
 
 !!! important
-
     If you do not own a domain, do not use it for your top level package. You can use your email, a subdomain of where you host a website, or your name/username as long as it can be unique.
 
 After the top level package (if you have one), you append a unique name for your mod, such as `examplemod`. In our case it will end up as `com.example.examplemod`.
@@ -18,7 +17,6 @@ The `mods.toml` file
 -------------------
 
 !!! important
-
     The license field in the mods.toml is required. If it is not provided, an error will occur. See your choices at https://choosealicense.com/
 
 This file defines the metadata of your mod. Its information may be viewed by users from the main screen of the game through the 'Mods' button. A single info file can describe several mods.
@@ -101,7 +99,6 @@ Rather than clutter up a single class and package with everything, it is recomme
 A common subpackage strategy has packages for `common` and `client` code, which is code that can be run on both server/client and only client, respectively. Inside the `common` package would go things like Items, Blocks, and Block Entities (which can each, in turn, be another subpackage). Things like Screens and Renderers would go inside the `client` package.
 
 !!! note
-
     This package style is only a suggestion, though it is a commonly used style. Feel free to use your own packaging system.
 
 By keeping your code in clean subpackages, you can grow your mod much more organically.

--- a/docs/legacy/index.md
+++ b/docs/legacy/index.md
@@ -4,7 +4,6 @@ Documentation for Legacy Versions
 Forge has existed for years, and you can still easily access builds of Forge for Minecraft versions as old as Minecraft 1.1. There are significant differences between each and every version, and it would be an impossible task to support so many different versions. Therefore, Forge uses an LTS system where a previous major Minecraft version is deemed as "LTS" (Long Term Support). Only the latest version and any current LTS versions will have easily accessible documentation and be included in the version dropdown in the sidebar. However, some older versions were LTS once or the latest version at some point and had documentation written. Links to old sites with documentation for those versions can be found here.
 
 !!! important
-
     These old documentation sites are for reference purposes only. Do not ask for help with old versions on the Forge discord or the Forge forums. **You will not receive support when you are using older versions.**
 
 ### List of Previously Documented versions

--- a/docs/models/itemproperties.md
+++ b/docs/models/itemproperties.md
@@ -15,7 +15,6 @@ There's also another method `ItemProperties#registerGeneric` that is used to add
     Use `FMLClientSetupEvent#enqueueWork` to proceed with the tasks, since the data structures in `ItemProperties` are not thread-safe.
 
 !!! note
-
     `ItemPropertyFunction` is deprecated by Mojang in favor of using the subinterface `ClampedItemPropertyFunction` which clamps the result between `0` and `1`.
 
 Using Overrides

--- a/docs/networking/simpleimpl.md
+++ b/docs/networking/simpleimpl.md
@@ -81,15 +81,11 @@ public static void handlePacket(MyClientMessage msg, Supplier<NetworkEvent.Conte
 Note the presence of `#setPacketHandled`, which is used to tell the network system that the packet has successfully completed handling.
 
 !!! warning
-
     As of Minecraft 1.8 packets are by default handled on the network thread.
 
-    That means that your handler can _not_ interact with most game objects directly.
-    Forge provides a convenient way to make your code execute on the main thread instead through the supplied `NetworkEvent$Context`.
-    Simply call `NetworkEvent$Context#enqueueWork(Runnable)`, which will call the given `Runnable` on the main thread at the next opportunity.
+    That means that your handler can _not_ interact with most game objects directly. Forge provides a convenient way to make your code execute on the main thread instead through the supplied `NetworkEvent$Context`. Simply call `NetworkEvent$Context#enqueueWork(Runnable)`, which will call the given `Runnable` on the main thread at the next opportunity.
 
 !!! warning
-
     Be defensive when handling packets on the server. A client could attempt to exploit the packet handling by sending unexpected data.
 
     A common problem is vulnerability to **arbitrary chunk generation**. This typically happens when the server is trusting a block position sent by a client to access blocks and block entities. When accessing blocks and block entities in unloaded areas of the level, the server will either generate or load this area from disk, then promptly write it to disk. This can be exploited to cause **catastrophic damage** to a server's performance and storage space without leaving a trace.

--- a/docs/rendering/bewlr.md
+++ b/docs/rendering/bewlr.md
@@ -27,7 +27,6 @@ public void initializeClient(Consumer<IItemRenderProperties> consumer) {
 ```
 
 !!! important
-
     Each mod should only have one instance of a custom BEWLR.
 
 That is it, no additional setup is necessary to use a BEWLR.

--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -15,7 +15,6 @@ Formatting
 ----------
 
 !!! important
-
     Please use **two spaces** to indent, not tabs.
 
 Titles should be capitalized in the standard titling format. For example,
@@ -32,3 +31,7 @@ Please use equals and dash underlines, instead of `#` and `##`. For h3 and lower
 When referencing fields and methods outside of code block snippets, they should use a `#` separator (e.g. `ClassName#methodName`). Inner classes should use a `$` separator (e.g. `ClassName$InnerClassName`).
 
 All links should have their location specified at the bottom of the page. Any internal links should reference the page via their relative path.
+
+Admonitions (represented by `!!! <type>`) must be formatted as [documented][admonition]; otherwise they may end up rendering incorrectly.
+
+[admonition]: https://python-markdown.github.io/extensions/admonition/

--- a/docs/utilities/recipes.md
+++ b/docs/utilities/recipes.md
@@ -41,7 +41,6 @@ A basic recipe file might look like the following example:
 ```
 
 !!! note
-
     When you first obtain an ingredient to a vanilla recipe, it will automatically unlock the recipe in the recipe book. To achieve the same effect, you have to use the [advancement][] system and create a new advancement for each of your ingredients.
 
     The advancement has to exist. This does not mean it has to be visible in the advancement tree.
@@ -69,7 +68,6 @@ A shapeless recipe does not make use of the `pattern` and `key` keywords.
 To define a shapeless recipe, you have to use the `ingredients` list. It defines which items have to be used for the crafting process. There are [many more][wiki] of these types which can be used here, and you can even register your own. It is even possible to define a slot that requires more than one of an item, which means multiple of these items have to be in place.
 
 !!! note
-
     While there is no limit on how many ingredients your recipe requires, the vanilla crafting table only allows 9 items to be placed for each crafting recipe.
 
 The following example shows how an ingredient list looks like within JSON:

--- a/docs/utilities/tags.md
+++ b/docs/utilities/tags.md
@@ -47,7 +47,7 @@ Item unknownItem = stack.getItem();
 boolean isInGroup = unknownItem.is(myTag);
 ```
 
-!!! note:
+!!! note
     The `TagCollection` returned by `#getAllTags` (and the `Tag`s within it) may expire if a reload happens.
     The static `Tag$Named` fields in `BlockTags` and `ItemTags` avoid this by introducing a wrapper that handles this expiring.
 


### PR DESCRIPTION
Admonitions, as added by the [admonition markdown extension](https://github.com/Python-Markdown/markdown/blob/master/markdown/extensions/admonition.py), tend to be formatted incorrectly causing bad rendering within the docs.

This PR aims to address that by fixing all current bugs and adding an additional convention to the style guide linking the documentation needed to add a proper admonition.