### PR TITLE
[1.14.x] Fix Theme Issue

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
 
 # Do not edit in PRs below here
 site_name: Forge Documentation
+site_url: https://mcforge.readthedocs.io/en/1.14.x/
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
This closes #293 since it seems that there is a bug starting from the deployed version of this mkdocs instance that if the `site_url` is not specified, then the theme fails to load.