### PR TITLE
[1.18.x] Fix Spacing and JSON Snippets

### DIFF
--- a/docs/advanced/accesstransformers.md
+++ b/docs/advanced/accesstransformers.md
@@ -13,7 +13,7 @@ Adding an Access Transformer to your mod project is as simple as adding a single
 ```groovy
 // This block is where your mappings version is also specified
 minecraft {
-    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+  accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 }
 ```
 
@@ -31,10 +31,10 @@ Access Modifiers
 
 Access modifiers specify to what new member visibility the given target will be transformed to. In decreasing order of visibility:
 
-  * `public` - visible to all classes inside and outside its package
-  * `protected` - visible only to classes inside the package and subclasses
-  * `default` - visible only to classes inside the package
-  * `private` - visible only to inside the class
+* `public` - visible to all classes inside and outside its package
+* `protected` - visible only to classes inside the package and subclasses
+* `default` - visible only to classes inside the package
+* `private` - visible only to inside the class
 
 A special modifier `+f` and `-f` can be appended to the aforementioned modifiers to either add or remove respectively the `final` modifier, which prevents subclassing, method overriding, or field modification when applied.
 
@@ -72,22 +72,22 @@ Targeting methods require a special syntax to denote the method parameters and r
 
 Also called "descriptors": see the [Java Virtual Machine Specification, SE 8, sections 4.3.2 and 4.3.3][jvmdescriptors] for more technical details.
 
-  * `B` - `byte`, a signed byte
-  * `C` - `char`, a Unicode character code point in UTF-16
-  * `D` - `double`, a double-precision floating-point value
-  * `F` - `float`, a single-precision floating-point value
-  * `I` - `integer`, a 32-bit integer
-  * `J` - `long`, a 64-bit integer
-  * `S` - `short`, a signed short
-  * `Z` - `boolean`, a `true` or `false` value
-  * `[` - references one dimension of an array
-    * Example: `[[S` refers to `short[][]`
-  * `L<class name>;` - references a reference type
-    * Example: `Ljava/lang/String;` refers to `java.lang.String` reference type _(note the use of slashes instead of periods)_
-  * `(` - references a method descriptor, parameters should be supplied here or nothing if no parameters are present
-    * Example: `<method>(I)Z` refers to a method that requires an integer argument and returns a boolean
-  * `V` - indicates a method returns no value, can only be used at the end of a method descriptor
-    * Example: `<method>()V` refers to a method that has no arguments and returns nothing
+* `B` - `byte`, a signed byte
+* `C` - `char`, a Unicode character code point in UTF-16
+* `D` - `double`, a double-precision floating-point value
+* `F` - `float`, a single-precision floating-point value
+* `I` - `integer`, a 32-bit integer
+* `J` - `long`, a 64-bit integer
+* `S` - `short`, a signed short
+* `Z` - `boolean`, a `true` or `false` value
+* `[` - references one dimension of an array
+  * Example: `[[S` refers to `short[][]`
+* `L<class name>;` - references a reference type
+  * Example: `Ljava/lang/String;` refers to `java.lang.String` reference type _(note the use of slashes instead of periods)_
+* `(` - references a method descriptor, parameters should be supplied here or nothing if no parameters are present
+ * Example: `<method>(I)Z` refers to a method that requires an integer argument and returns a boolean
+* `V` - indicates a method returns no value, can only be used at the end of a method descriptor
+  * Example: `<method>()V` refers to a method that has no arguments and returns nothing
 
 Examples
 --------

--- a/docs/blocks/states.md
+++ b/docs/blocks/states.md
@@ -10,11 +10,11 @@ However, the metadata system was confusing and limited, since it was stored as o
 
 ```Java
 switch (meta) {
-    case 0: { ... } // south and on the lower half of the block
-    case 1: { ... } // south on the upper side of the block
-    case 2: { ... } // north and on the lower half of the block
-    case 3: { ... } // north and on the upper half of the block
-    ... etc. ...
+  case 0: { ... } // south and on the lower half of the block
+  case 1: { ... } // south on the upper side of the block
+  case 2: { ... } // north and on the lower half of the block
+  case 3: { ... } // north and on the upper half of the block
+  // ... etc. ...
 }
 ```
 
@@ -49,19 +49,19 @@ Implementing Block States
 
 In your Block class, create or reference `static final` `Property<?>` objects for every property that your Block has. You are free to make your own `Property<?>` implementations, but the means to do that are not covered in this article. The vanilla code provides several convenience implementations:
 
-  * `IntegerProperty`
-    * Implements `Property<Integer>`. Defines a property that holds an integer value.
-    * Created by calling `IntegerProperty#create(String propertyName, int minimum, int maximum)`.
-  * `BooleanProperty`
-    * Implements `Property<Boolean>`. Defines a property that holds a `true` or `false` value.
-    * Created by calling `BooleanProperty#create(String propertyName)`.
-  * `EnumProperty<E extends Enum<E>>`
-    * Implements `Property<E>`. Defines a property that can take on the values of an Enum class.
-    * Created by calling `EnumProperty#create(String propertyName, Class<E> enumClass)`.
-    * It is also possible to use only a subset of the Enum values (e.g. 4 out of 16 `DyeColor`s). See the overloads of `EnumProperty#create`.
-  * `DirectionProperty`
-    * This is a convenience implementation of `EnumProperty<Direction>`
-    * Several convenience predicates are also provided. For example, to get a property that represents the cardinal directions, call `DirectionProperty.create("<name>", Direction.Plane.HORIZONTAL)`; to get the X directions, `DirectionProperty.create("<name>", Direction.Axis.X)`.
+* `IntegerProperty`
+  * Implements `Property<Integer>`. Defines a property that holds an integer value.
+  * Created by calling `IntegerProperty#create(String propertyName, int minimum, int maximum)`.
+* `BooleanProperty`
+  * Implements `Property<Boolean>`. Defines a property that holds a `true` or `false` value.
+  * Created by calling `BooleanProperty#create(String propertyName)`.
+* `EnumProperty<E extends Enum<E>>`
+  * Implements `Property<E>`. Defines a property that can take on the values of an Enum class.
+  * Created by calling `EnumProperty#create(String propertyName, Class<E> enumClass)`.
+  * It is also possible to use only a subset of the Enum values (e.g. 4 out of 16 `DyeColor`s). See the overloads of `EnumProperty#create`.
+* `DirectionProperty`
+  * This is a convenience implementation of `EnumProperty<Direction>`
+  * Several convenience predicates are also provided. For example, to get a property that represents the cardinal directions, call `DirectionProperty.create("<name>", Direction.Plane.HORIZONTAL)`; to get the X directions, `DirectionProperty.create("<name>", Direction.Axis.X)`.
 
 The class `BlockStateProperties` contains shared vanilla properties which should be used or referenced whenever possible, in place of creating your own properties.
 
@@ -71,12 +71,12 @@ Every block will also have a "default" state that is automatically chosen for yo
 
 ```Java
 this.registerDefaultState(
-    this.stateDefinition.any()
-        .setValue(FACING, Direction.NORTH)
-        .setValue(OPEN, false)
-        .setValue(HINGE, DoorHingeSide.LEFT)
-        .setValue(POWERED, false)
-        .setValue(HALF, DoubleBlockHalf.LOWER)
+  this.stateDefinition.any()
+    .setValue(FACING, Direction.NORTH)
+    .setValue(OPEN, false)
+    .setValue(HINGE, DoorHingeSide.LEFT)
+    .setValue(POWERED, false)
+    .setValue(HALF, DoubleBlockHalf.LOWER)
 );
 ```
 

--- a/docs/concepts/lifecycle.md
+++ b/docs/concepts/lifecycle.md
@@ -8,17 +8,17 @@ Event listeners should be registered either using `@EventBusSubscriber(bus = Bus
 ```Java
 @Mod.EventBusSubscriber(modid = "mymod", bus = Mod.EventBusSubscriber.Bus.MOD)
 public class MyModEventSubscriber {
-    @SubscribeEvent
-    static void onCommonSetup(FMLCommonSetupEvent event) { ... }
+  @SubscribeEvent
+  static void onCommonSetup(FMLCommonSetupEvent event) { ... }
 }
 
 @Mod("mymod")
 public class MyMod {
-    public MyMod() {
-        FMLModLoadingContext.get().getModEventBus().addListener(this::onCommonSetup);
-    } 
-  
-    private void onCommonSetup(FMLCommonSetupEvent event) { ... }
+  public MyMod() {
+    FMLModLoadingContext.get().getModEventBus().addListener(this::onCommonSetup);
+  } 
+
+  private void onCommonSetup(FMLCommonSetupEvent event) { ... }
 }
 ```
 

--- a/docs/concepts/registries.md
+++ b/docs/concepts/registries.md
@@ -24,7 +24,7 @@ private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(Fo
 public static final RegistryObject<Block> ROCK_BLOCK = BLOCKS.register("rock", () -> new Block(BlockBehaviour.Properties.of(Material.STONE)));
 
 public ExampleMod() {
-    BLOCKS.register(FMLJavaModLoadingContext.get().getModEventBus());
+  BLOCKS.register(FMLJavaModLoadingContext.get().getModEventBus());
 }
 ```
 
@@ -39,7 +39,7 @@ Here is an example: (the event handler is registered on the *mod event bus*)
 ```java
 @SubscribeEvent
 public void registerBlocks(RegistryEvent.Register<Block> event) {
-    event.getRegistry().registerAll(new Block(...), new Block(...), ...);
+  event.getRegistry().registerAll(new Block(...), new Block(...), ...);
 }
 ```
 
@@ -59,7 +59,7 @@ The appropriate time to populate these objects is in `FMLCommonSetupEvent`. Beca
     These factories are created through the use of their `*Type$Builder` classes. An example: (`REGISTER` refers to a `DeferredRegister<BlockEntityType>`)
     ```java
     public static final RegistryObject<BlockEntityType<ExampleBlockEntity>> EXAMPLE_BLOCK_ENTITY = REGISTER.register(
-        "example_block_entity", () -> BlockEntityType.Builder.of(ExampleBlockEntity::new, EXAMPLE_BLOCK.get()).build(null)
+      "example_block_entity", () -> BlockEntityType.Builder.of(ExampleBlockEntity::new, EXAMPLE_BLOCK.get()).build(null)
     );
     ```
 
@@ -94,17 +94,17 @@ The rules for `@ObjectHolder` are as follows:
 * If the class is annotated with `@ObjectHolder`, its value will be the default namespace for all fields within if not explicitly defined
 * If the class is annotated with `@Mod`, the modid will be the default namespace for all annotated fields within if not explicitly defined
 * A field is considered for injection if:
-    * it has at least the modifiers `public static`;
-    * one of the following conditions are true:
-        * the **enclosing class** has an `@ObjectHolder` annotation, and the field is `final`, and:
-            * the name value is the field's name; and
-            * the namespace value is the enclosing class's namespace
-            * _An exception is thrown if the namespace value cannot be found and inherited_
-        * the **field** is annotated with `@ObjectHolder`, and:
-            * the name value is explicitly defined; and
-            * the namespace value is either explicitly defined or the enclosing class's namespace
-    * the field type or one of its supertypes corresponds to a valid registry (e.g. `Item` or `ArrowItem` for the `Item` registry);
-    * _An exception is thrown if a field does not have a corresponding registry._
+  * it has at least the modifiers `public static`;
+  * one of the following conditions are true:
+    * the **enclosing class** has an `@ObjectHolder` annotation, and the field is `final`, and:
+      * the name value is the field's name; and
+      * the namespace value is the enclosing class's namespace
+      * _An exception is thrown if the namespace value cannot be found and inherited_
+    * the **field** is annotated with `@ObjectHolder`, and:
+      * the name value is explicitly defined; and
+      * the namespace value is either explicitly defined or the enclosing class's namespace
+  * the field type or one of its supertypes corresponds to a valid registry (e.g. `Item` or `ArrowItem` for the `Item` registry);
+  * _An exception is thrown if a field does not have a corresponding registry._
 * _An exception is thrown if the resulting `ResourceLocation` is incomplete or invalid (non-valid characters in path)_
 * If no other errors or exceptions occur, the field will be injected
 * If all of the above rules do not apply, no action will be taken (and a message may be logged)
@@ -118,76 +118,76 @@ As these rules are rather complicated, here are some examples:
 ```java
 @ObjectHolder("minecraft") // Inheritable resource namespace: "minecraft"
 class AnnotatedHolder {
-    public static final Block diamond_block = null;   // No annotation. [public static final] is required.
-                                                      // Block has a corresponding registry: [Block]
-                                                      // Name path is the name of the field: "diamond_block"
-                                                      // Namespace is not explicitly defined.
-                                                      // So, namespace is inherited from class annotation: "minecraft"
-                                                      // To inject: "minecraft:diamond_block" from the [Block] registry
+  public static final Block diamond_block = null;   // No annotation. [public static final] is required.
+                                                    // Block has a corresponding registry: [Block]
+                                                    // Name path is the name of the field: "diamond_block"
+                                                    // Namespace is not explicitly defined.
+                                                    // So, namespace is inherited from class annotation: "minecraft"
+                                                    // To inject: "minecraft:diamond_block" from the [Block] registry
 
-    @ObjectHolder("ambient.cave")
-    public static SoundEvent ambient_sound = null;    // Annotation present. [public static] is required.
-                                                      // SoundEvent has a corresponding registry: [SoundEvent]
-                                                      // Name path is the value of the annotation: "ambient.cave"
-                                                      // Namespace is not explicitly defined.
-                                                      // So, namespace is inherited from class annotation: "minecraft"
-                                                      // To inject: "minecraft:ambient.cave" from the [SoundEvent] registry
+  @ObjectHolder("ambient.cave")
+  public static SoundEvent ambient_sound = null;    // Annotation present. [public static] is required.
+                                                    // SoundEvent has a corresponding registry: [SoundEvent]
+                                                    // Name path is the value of the annotation: "ambient.cave"
+                                                    // Namespace is not explicitly defined.
+                                                    // So, namespace is inherited from class annotation: "minecraft"
+                                                    // To inject: "minecraft:ambient.cave" from the [SoundEvent] registry
 
-    // Assume for the next entry that [ManaType] is a valid registry.          
-    @ObjectHolder("neomagicae:coffeinum")
-    public static final ManaType coffeinum = null;    // Annotation present. [public static] is required. [final] is optional.
-                                                      // ManaType has a corresponding registry: [ManaType] (custom registry)
-                                                      // Resource location is explicitly defined: "neomagicae:coffeinum"
-                                                      // To inject: "neomagicae:coffeinum" from the [ManaType] registry
+  // Assume for the next entry that [ManaType] is a valid registry.          
+  @ObjectHolder("neomagicae:coffeinum")
+  public static final ManaType coffeinum = null;    // Annotation present. [public static] is required. [final] is optional.
+                                                    // ManaType has a corresponding registry: [ManaType] (custom registry)
+                                                    // Resource location is explicitly defined: "neomagicae:coffeinum"
+                                                    // To inject: "neomagicae:coffeinum" from the [ManaType] registry
 
-    public static final Item ENDER_PEARL = null;      // No annotation. [public static final] is required.
-                                                      // Item has a corresponding registry: [Item].
-                                                      // Name path is the name of the field: "ENDER_PEARL" -> "ender_pearl"
-                                                      // !! ^ Field name is valid, because they are
-                                                      //      converted to lowercase automatically.
-                                                      // Namespace is not explicitly defined.
-                                                      // So, namespace is inherited from class annotation: "minecraft"
-                                                      // To inject: "minecraft:ender_pearl" from the [Item] registry
+  public static final Item ENDER_PEARL = null;      // No annotation. [public static final] is required.
+                                                    // Item has a corresponding registry: [Item].
+                                                    // Name path is the name of the field: "ENDER_PEARL" -> "ender_pearl"
+                                                    // !! ^ Field name is valid, because they are
+                                                    //      converted to lowercase automatically.
+                                                    // Namespace is not explicitly defined.
+                                                    // So, namespace is inherited from class annotation: "minecraft"
+                                                    // To inject: "minecraft:ender_pearl" from the [Item] registry
 
-    @ObjectHolder("minecraft:arrow")
-    public static final ArrowItem arrow = null;       // Annotation present. [public static] is required. [final] is optional.
-                                                      // ArrowItem does not have a corresponding registry.
-                                                      // ArrowItem's supertype of Item has a corresponding registry: [Item]
-                                                      // Resource location is explicitly defined: "minecraft:arrow"
-                                                      // To inject: "minecraft:arrow" from the [Item] registry                                                    
+  @ObjectHolder("minecraft:arrow")
+  public static final ArrowItem arrow = null;       // Annotation present. [public static] is required. [final] is optional.
+                                                    // ArrowItem does not have a corresponding registry.
+                                                    // ArrowItem's supertype of Item has a corresponding registry: [Item]
+                                                    // Resource location is explicitly defined: "minecraft:arrow"
+                                                    // To inject: "minecraft:arrow" from the [Item] registry                                                    
 
-    public static Block bedrock = null;               // No annotation, so [public static final] is required.
-                                                      // Therefore, the field is ignored.
+  public static Block bedrock = null;               // No annotation, so [public static final] is required.
+                                                    // Therefore, the field is ignored.
     
-    public static final CreativeModeTab group = null; // No annotation. [public static final] is required.
-                                                      // CreativeModeTab does not have a corresponding registry.
-                                                      // No supertypes of CreativeModeTab has a corresponding registry.
-                                                      // Therefore, THIS WILL PRODUCE AN EXCEPTION.
+  public static final CreativeModeTab group = null; // No annotation. [public static final] is required.
+                                                    // CreativeModeTab does not have a corresponding registry.
+                                                    // No supertypes of CreativeModeTab has a corresponding registry.
+                                                    // Therefore, THIS WILL PRODUCE AN EXCEPTION.
 }
 
 class UnannotatedHolder { // Note the lack of an @ObjectHolder annotation on this class.
-    @ObjectHolder("minecraft:flame")
-    public static final Enchantment flame = null;     // Annotation present. [public static] is required. [final] is optional.
-                                                      // Enchantment has corresponding registry: [Enchantment].
-                                                      // Resource location is explicitly defined: "minecraft:flame"
-                                                      // To inject: "minecraft:flame" from the [Enchantment] registry
+  @ObjectHolder("minecraft:flame")
+  public static final Enchantment flame = null;     // Annotation present. [public static] is required. [final] is optional.
+                                                    // Enchantment has corresponding registry: [Enchantment].
+                                                    // Resource location is explicitly defined: "minecraft:flame"
+                                                    // To inject: "minecraft:flame" from the [Enchantment] registry
 
-    public static final Biome ice_flat = null;        // No annotation on the enclosing class.
-                                                      // Therefore, the field is ignored.
+  public static final Biome ice_flat = null;        // No annotation on the enclosing class.
+                                                    // Therefore, the field is ignored.
 
-    @ObjectHolder("minecraft:creeper")
-    public static Entity creeper = null;              // Annotation present. [public static] is required.
-                                                      // Entity does not have a corresponding registry.
-                                                      // No supertypes of Entity has a corresponding registry.
-                                                      // Therefore, THIS WILL PRODUCE AN EXCEPTION.
+  @ObjectHolder("minecraft:creeper")
+  public static Entity creeper = null;              // Annotation present. [public static] is required.
+                                                    // Entity does not have a corresponding registry.
+                                                    // No supertypes of Entity has a corresponding registry.
+                                                    // Therefore, THIS WILL PRODUCE AN EXCEPTION.
 
-    @ObjectHolder("levitation")
-    public static final Potion levitation = null;     // Annotation present. [public static] is required. [final] is optional.
-                                                      // Potion has a corresponding registry: [Potion].
-                                                      // Name path is the value of the annotation: "levitation"
-                                                      // Namespace is not explicitly defined.
-                                                      // No annotation in enclosing class.
-                                                      // Therefore, THIS WILL PRODUCE AN EXCEPTION.
+  @ObjectHolder("levitation")
+  public static final Potion levitation = null;     // Annotation present. [public static] is required. [final] is optional.
+                                                    // Potion has a corresponding registry: [Potion].
+                                                    // Name path is the value of the annotation: "levitation"
+                                                    // Namespace is not explicitly defined.
+                                                    // No annotation in enclosing class.
+                                                    // Therefore, THIS WILL PRODUCE AN EXCEPTION.
 }
 ```
 

--- a/docs/concepts/sides.md
+++ b/docs/concepts/sides.md
@@ -46,11 +46,11 @@ These two methods are subdivided further into `#safe*` and `#unsafe*` variants. 
 ```java
 // In a client class: ExampleClass
 public static void unsafeRunMethodExample(Object param1, Object param2) {
-    // ...
+  // ...
 }
 
 public static Object safeCallMethodExample() {
-    // ...
+  // ...
 }
 
 // In some common class

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,8 +16,8 @@ Style Guide
 
 Titles should be capitalized in the standard titling format. For example,
 
-  * Guide For Contributing to This Documentation
-  * Building and Testing Your Mod
+* Guide For Contributing to This Documentation
+* Building and Testing Your Mod
 
 Essentially, capitalize everything but unimportant words.
 

--- a/docs/datagen/index.md
+++ b/docs/datagen/index.md
@@ -12,18 +12,18 @@ Generator Modes
 
 The data generator can be configured to run 4 different data generations, which are configured from the command-line parameters, and can be checked from `GatherDataEvent#include***` methods.
 
-  * __Client Assets__
-  	 * Generates client-only files in `assets`: block/item models, blockstate JSONs, language files, etc.
-     * __`--client`__, `includeClient()`
-  * __Server Data__
-  	 * Generates server-only files in `data`: recipes, advancements, tags, etc.
-     * __`--server`__, `includeServer()`
-  * __Development Tools__
-  	 * Runs some development tools: converting SNBT to NBT and vice-versa, etc.
-     * __`--dev`__, `includeDev()`
-  * __Reports__
-  	 * Dumps all registered blocks, items, commands, etc.
-     * __`--reports`__, `includeReports()`
+* __Client Assets__
+  * Generates client-only files in `assets`: block/item models, blockstate JSONs, language files, etc.
+  * __`--client`__, `includeClient()`
+* __Server Data__
+  * Generates server-only files in `data`: recipes, advancements, tags, etc.
+  * __`--server`__, `includeServer()`
+* __Development Tools__
+  * Runs some development tools: converting SNBT to NBT and vice-versa, etc.
+  * __`--dev`__, `includeDev()`
+* __Reports__
+  * Dumps all registered blocks, items, commands, etc.
+  * __`--reports`__, `includeReports()`
 
 Data Providers
 --------------
@@ -34,20 +34,20 @@ Minecraft has abstract implementations for most assets and data, so modders need
 The `GatherDataEvent` is fired on the mod event bus when the data generator is being created, and the `DataGenerator` can be obtained from the event. Create and register data providers using `DataGenerator#addProvider`.
 
 ### Client Assets
-  * `net.minecraftforge.common.data.LanguageProvider` - for language strings; override `#addTranslations`
-  * `ModelProvider<?>` - base class for all model providers
-    * _These classes are under the `net.minecraftforge.client.model.generators` package_
-    * `ItemModelProvider` - for item models; override `#registerModels`
-    * `BlockStateProvider` - for blockstates and their block and item models; override `#registerStatesAndModels`
-    * `BlockModelProvider` - for block models; override `#registerModels`
-  * `net.minecraftforge.common.data.SoundDefinitionsProvider` - for the `sounds.json`
+* `net.minecraftforge.common.data.LanguageProvider` - for language strings; override `#addTranslations`
+* `ModelProvider<?>` - base class for all model providers
+  * _These classes are under the `net.minecraftforge.client.model.generators` package_
+  * `ItemModelProvider` - for item models; override `#registerModels`
+  * `BlockStateProvider` - for blockstates and their block and item models; override `#registerStatesAndModels`
+  * `BlockModelProvider` - for block models; override `#registerModels`
+* `net.minecraftforge.common.data.SoundDefinitionsProvider` - for the `sounds.json`
 
 ### Server Data
-  * `net.minecraftforge.common.data.GlobalLootModifierProvider` - for [global loot modifiers][glm]; override `#start`
-  * _These classes are under the `net.minecraft.data` package_
-  * `LootTableProvider` - for loot tables; override `#getTables`
-  * `RecipeProvider` - for recipes and their unlocking advancements; override `#buildCraftingRecipes`
-  * `TagsProvider` - for tags; override `#addTags`
-  * `AdvancementProvider` - for advancements; override `#registerAdvancements`
+* `net.minecraftforge.common.data.GlobalLootModifierProvider` - for [global loot modifiers][glm]; override `#start`
+* _These classes are under the `net.minecraft.data` package_
+* `LootTableProvider` - for loot tables; override `#getTables`
+* `RecipeProvider` - for recipes and their unlocking advancements; override `#buildCraftingRecipes`
+* `TagsProvider` - for tags; override `#addTags`
+* `AdvancementProvider` - for advancements; override `#registerAdvancements`
 
 [glm]: ../resources/server/glm.md

--- a/docs/datastorage/capabilities.md
+++ b/docs/datastorage/capabilities.md
@@ -99,7 +99,7 @@ In general terms, a capability is registered through the event `RegisterCapabili
 ```java
 @SubscribeEvent
 public void registerCaps(RegisterCapabilitiesEvent event) {
-    event.register(IExampleCapability.class);
+  event.register(IExampleCapability.class);
 }
 ```
 
@@ -121,7 +121,7 @@ public class MyBlockEntity extends BlockEntity {
     }
   }
 
-  ...
+  // ...
 }
 ```
 

--- a/docs/forgedev/index.md
+++ b/docs/forgedev/index.md
@@ -49,7 +49,7 @@ Due to the way Eclipse workspaces work, ForgeGradle can do most of the work invo
 3. Type `./gradlew genEclipseRuns` and hit enter. Once again, wait until ForgeGradle is done.
 4. Open your Eclipse workspace and go to `File -> Import -> General -> Existing Gradle Project`.
 5. Browse to the repo directory for the "Project root directory" option in the dialog that opens.
-7. Complete the import by clicking the "Finish" button.
+6. Complete the import by clicking the "Finish" button.
 
 That is all it takes to get you up and running with Eclipse. There is no extra steps required to get the test mods running. Simply hit "Run" like in any other project and select the appropriate run configuration.
 

--- a/docs/forgedev/index.md
+++ b/docs/forgedev/index.md
@@ -44,12 +44,12 @@ Depending on your favorite IDE, there is a different set of recommended steps yo
 
 Due to the way Eclipse workspaces work, ForgeGradle can do most of the work involved to get you started with a Forge workspace.
 
- 1. Open a terminal/command prompt and navigate to the directory of your cloned fork.
- 2. Type `./gradlew setup` and hit enter. Wait until ForgeGradle is done.
- 3. Type `./gradlew genEclipseRuns` and hit enter. Once again, wait until ForgeGradle is done.
- 4. Open your Eclipse workspace and go to `File -> Import -> General -> Existing Gradle Project`.
- 5. Browse to the repo directory for the "Project root directory" option in the dialog that opens.
- 7. Complete the import by clicking the "Finish" button.
+1. Open a terminal/command prompt and navigate to the directory of your cloned fork.
+2. Type `./gradlew setup` and hit enter. Wait until ForgeGradle is done.
+3. Type `./gradlew genEclipseRuns` and hit enter. Once again, wait until ForgeGradle is done.
+4. Open your Eclipse workspace and go to `File -> Import -> General -> Existing Gradle Project`.
+5. Browse to the repo directory for the "Project root directory" option in the dialog that opens.
+7. Complete the import by clicking the "Finish" button.
 
 That is all it takes to get you up and running with Eclipse. There is no extra steps required to get the test mods running. Simply hit "Run" like in any other project and select the appropriate run configuration.
 
@@ -90,14 +90,14 @@ That is all there is to creating a Forge development environment in IntelliJ IDE
 
 To enable the test mods coming with Forge, you will need to add the compiler output to the classpath. Again, cpw has put up [a video][testsetup] explaining these steps for IDEA 2016.1.
 
- 1. Build the test classes by selecting the `src/main/test` directory in your project view and then run `Build -> Build module 'Forge_test'` from the menu bar.
- 2. Open the "Project Structure" window under `File -> Project Structure`.
- 3. Head to the "Modules" section and expand the `Forge` module.
- 4. Select the `Forge_test` submodule and head to the "Paths" tab.
- 5. Remember the path listed under the "Test output path" label and select the `Forge_main` submodule from the tree.
- 6. Open the "Dependencies" tab, hit the green plus button on the right-hand side, and select "JARs or directories".
- 7. Navigate to the path previously displayed as the `Forge_test` output path and confirm your selection.
- 8. For the "Scope" of this newly added dependency (currently "Compile") choose "Runtime", since the main code does not rely on the test code for compilation.
+1. Build the test classes by selecting the `src/main/test` directory in your project view and then run `Build -> Build module 'Forge_test'` from the menu bar.
+2. Open the "Project Structure" window under `File -> Project Structure`.
+3. Head to the "Modules" section and expand the `Forge` module.
+4. Select the `Forge_test` submodule and head to the "Paths" tab.
+5. Remember the path listed under the "Test output path" label and select the `Forge_main` submodule from the tree.
+6. Open the "Dependencies" tab, hit the green plus button on the right-hand side, and select "JARs or directories".
+7. Navigate to the path previously displayed as the `Forge_test` output path and confirm your selection.
+8. For the "Scope" of this newly added dependency (currently "Compile") choose "Runtime", since the main code does not rely on the test code for compilation.
 
 Now that you have added the test mods to the classpath, you need to rebuild them each time you make a change, as they will not be built automatically. To do so, repeat step 1 from the above list or, in case you make changes to a single test mod file and want them to get rebuilt, simply hit `Build -> Rebuild project` or the corresponding keyboard shortcut (CTRL+F9 by default).
 
@@ -105,14 +105,14 @@ Now that you have added the test mods to the classpath, you need to rebuild them
 
 You might want to test changes in Forge with an existing project. The [video][testsetup] by cpw linked in the test mods section also covers this for IDEA 2016.1. Getting the mod to run requires similar steps to the test mod, but getting your project added to the workspace requires some additional work.
 
- 1. Open the "Project Structure" Window under `File -> Project Structure`.
- 2. Head to the "Modules" section and press the green plus icon above the tree view.
- 3. Select "Import Module", navigate to your project's `build.gradle` file, and confirm your selection as well as the import settings.
- 4. Close the "Project Structure" window by clicking the "OK" button.
- 5. Reopen the window after IDEA is done importing the project and select your project's `_main` module from the tree.
- 6. Open the "Dependencies" tab, click the green plus icon on the right-hand side, and select "Module dependency".
- 7. In the window that just opened, select the `Forge_main` module.
- 8. From here on, reproduce the steps from the test mods section, just with your project's `_main` module instead of the `Forge_test` one.
+1. Open the "Project Structure" Window under `File -> Project Structure`.
+2. Head to the "Modules" section and press the green plus icon above the tree view.
+3. Select "Import Module", navigate to your project's `build.gradle` file, and confirm your selection as well as the import settings.
+4. Close the "Project Structure" window by clicking the "OK" button.
+5. Reopen the window after IDEA is done importing the project and select your project's `_main` module from the tree.
+6. Open the "Dependencies" tab, click the green plus icon on the right-hand side, and select "Module dependency".
+7. In the window that just opened, select the `Forge_main` module.
+8. From here on, reproduce the steps from the test mods section, just with your project's `_main` module instead of the `Forge_test` one.
 
 !!! note
     You might need to remove existing dependencies from a normal development environment (mainly references to a `forgeSrc` JAR) or move the Forge module higher up in the dependency list.

--- a/docs/gameeffects/sounds.md
+++ b/docs/gameeffects/sounds.md
@@ -62,8 +62,7 @@ Note that each takes a `SoundEvent`, the ones registered above. Additionally, th
 2. <a name="level-playsound-pxyzecvp"></a> `playSound(Player, double x, double y, double z, SoundEvent, SoundCategory, volume, pitch)`
     - **Client Behavior**: If the passed in player is *the* client player, plays the sound event to the client player.
     - **Server Behavior**: Plays the sound event to everyone nearby **except** the passed in player. Player can be `null`.
-    - **Usage**: The correspondence between the behaviors implies that these two methods are to be called from some player-initiated code that will be run on both logical sides at the same time: the logical client handles playing it to the user, and the logical server handles everyone else hearing it without re-playing it to the original user.
-       They can also be used to play any sound in general at any position server-side by calling it on the logical server and passing in a `null` player, thus letting everyone hear it.
+    - **Usage**: The correspondence between the behaviors implies that these two methods are to be called from some player-initiated code that will be run on both logical sides at the same time: the logical client handles playing it to the user, and the logical server handles everyone else hearing it without re-playing it to the original user. They can also be used to play any sound in general at any position server-side by calling it on the logical server and passing in a `null` player, thus letting everyone hear it.
 
 3. <a name="level-playsound-xyzecvpd"></a> `playLocalSound(double x, double y, double z, SoundEvent, SoundCategory, volume, pitch, distanceDelay)`
     - **Client Behavior**: Just plays the sound event in the client level. If `distanceDelay` is `true`, then delays the sound based on how far it is from the player.

--- a/docs/gettingstarted/structuring.md
+++ b/docs/gettingstarted/structuring.md
@@ -23,45 +23,45 @@ This file defines the metadata of your mod. Its information may be viewed by use
 
 The `mods.toml` file is formatted as [TOML][], the example `mods.toml` file in the MDK provides comments explaining the contents of the file. It should be stored as `src/main/resources/META-INF/mods.toml`. A basic `mods.toml`, describing one mod, may look like this:
 ```toml
-    # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
-    modLoader="javafml"
-    # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-    # Forge for 1.18 is version 38
-    loaderVersion="[38,)"
-    # The license for your mod. This is mandatory and allows for easier comprehension of your redistributive properties.
-    # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
-    license="All Rights Reserved"
-    # A URL to refer people to when problems occur with this mod
-    issueTrackerURL="github.com/MinecraftForge/MinecraftForge/issues"
-    # If the mods defined in this file should show as separate resource packs
-    showAsResourcePack=false
+# The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
+modLoader="javafml"
+# A version range to match for said mod loader - for regular FML @Mod it will be the forge version
+# Forge for 1.18 is version 38
+loaderVersion="[38,)"
+# The license for your mod. This is mandatory and allows for easier comprehension of your redistributive properties.
+# Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
+license="All Rights Reserved"
+# A URL to refer people to when problems occur with this mod
+issueTrackerURL="github.com/MinecraftForge/MinecraftForge/issues"
+# If the mods defined in this file should show as separate resource packs
+showAsResourcePack=false
 
-    [[mods]]
-      modId="examplemod"
-      version="1.0.0.0"
-      displayName="Example Mod"
-      updateJSONURL="minecraftforge.net/versions.json"
-      displayURL="minecraftforge.net"
-      logoFile="logo.png"
-      credits="I'd like to thank my mother and father."
-      authors="Author"
-      description='''
-      Lets you craft dirt into diamonds. This is a traditional mod that has existed for eons. It is ancient. The holy Notch created it. Jeb rainbowfied it. Dinnerbone made it upside down. Etc.
-      '''
+[[mods]]
+  modId="examplemod"
+  version="1.0.0.0"
+  displayName="Example Mod"
+  updateJSONURL="minecraftforge.net/versions.json"
+  displayURL="minecraftforge.net"
+  logoFile="logo.png"
+  credits="I'd like to thank my mother and father."
+  authors="Author"
+  description='''
+  Lets you craft dirt into diamonds. This is a traditional mod that has existed for eons. It is ancient. The holy Notch created it. Jeb rainbowfied it. Dinnerbone made it upside down. Etc.
+  '''
 
-      [[dependencies.examplemod]]
-        modId="forge"
-        mandatory=true
-        versionRange="[38,)"
-        ordering="NONE"
-        side="BOTH"
+  [[dependencies.examplemod]]
+    modId="forge"
+    mandatory=true
+    versionRange="[38,)"
+    ordering="NONE"
+    side="BOTH"
 
-      [[dependencies.examplemod]]
-        modId="minecraft"
-        mandatory=true
-        versionRange="[1.18,1.19)"
-        ordering="NONE"
-        side="BOTH"
+  [[dependencies.examplemod]]
+    modId="minecraft"
+    mandatory=true
+    versionRange="[1.18,1.19)"
+    ordering="NONE"
+    side="BOTH"
 ```
 
 If any string is specified as `${file.jarVersion}`, Forge will replace the string with the **Implementation Version** specified in your jar manifest at runtime. Since the user development environment has no jar manifest to pull from, it will be `NONE` instead. As such, it is usually recommended to leave the `version` field alone. Here is a table of attributes that may be given to a mod, where `mandatory` means there is no default and the absence of the property causes an error.

--- a/docs/gettingstarted/versioning.md
+++ b/docs/gettingstarted/versioning.md
@@ -9,21 +9,21 @@ Examples
 Here is a list of examples that can increment the various variables.
 
 * `MCVERSION`
-	* Always matches the Minecraft version the mod is for.
+  * Always matches the Minecraft version the mod is for.
 * `MAJORMOD`
-	* Removing items, blocks, block entities, etc.
-	* Changing or removing previously existing mechanics.
-	* Updating to a new Minecraft version.
+  * Removing items, blocks, block entities, etc.
+  * Changing or removing previously existing mechanics.
+  * Updating to a new Minecraft version.
 * `MAJORAPI`
-	* Changing the order or variables of enums.
-	* Changing return types of methods.
-	* Removing public methods altogether.
+  * Changing the order or variables of enums.
+  * Changing return types of methods.
+  * Removing public methods altogether.
 * `MINOR`
-	* Adding items, blocks, block entities, etc.
-	* Adding new mechanics.
-	* Deprecating public methods. (This is not a `MAJORAPI` increment since it doesn't break an API.)
+  * Adding items, blocks, block entities, etc.
+  * Adding new mechanics.
+  * Deprecating public methods. (This is not a `MAJORAPI` increment since it doesn't break an API.)
 * `PATCH`
-	* Bugfixes.
+  * Bugfixes.
 
 When incrementing any variable, all lesser variables should reset to `0`. For instance, if `MINOR` would increment, `PATCH` would become `0`. If `MAJORMOD` would increment, all other variables would become `0`.
 

--- a/docs/misc/debugprofiler.md
+++ b/docs/misc/debugprofiler.md
@@ -38,9 +38,9 @@ Here is a small explanation of what each part means
 
 The Debug Profiler has basic support for `Entity` and `BlockEntity`. If you would like to profile something else, you may need to manually create your sections like so:
 ```java
-  ProfilerFiller#push(yourSectionName : String);
-  //The code you want to profile
-  ProfilerFiller#pop();
+ProfilerFiller#push(yourSectionName : String);
+//The code you want to profile
+ProfilerFiller#pop();
 ```
 You can obtain the `ProfilerFiller` instance from a `Level`, `MinecraftServer`, or `Minecraft` instance.
 Now you just need to search the results file for your section name.

--- a/docs/misc/updatechecker.md
+++ b/docs/misc/updatechecker.md
@@ -13,20 +13,20 @@ Update JSON format
 
 The JSON itself has a relatively simple format as follows:
 
-```Javascript
+```json5
 {
   "homepage": "<homepage/download page for your mod>",
   "<mcversion>": {
     "<modversion>": "<changelog for this version>", 
     // List all versions of your mod for the given Minecraft version, along with their changelogs
-    ...
+    // ...
   },
   "promos": {
     "<mcversion>-latest": "<modversion>",
     // Declare the latest "bleeding-edge" version of your mod for the given Minecraft version
     "<mcversion>-recommended": "<modversion>",
     // Declare the latest "stable" version of your mod for the given Minecraft version
-    ...
+    // ...
   }
 }
 ```

--- a/docs/networking/index.md
+++ b/docs/networking/index.md
@@ -6,9 +6,9 @@ Communication between servers and clients is the backbone of a successful mod im
 There are two primary goals in network communication:
 
 1. Making sure the client view is "in sync" with the server view
-  - The flower at coordinates (X, Y, Z) just grew
+    - The flower at coordinates (X, Y, Z) just grew
 2. Giving the client a way to tell the server that something has changed about the player
-  - the player pressed a key
+    - the player pressed a key
 
 The most common way to accomplish these goals is to pass messages between the client and the server. These messages will usually be structured, containing data in a particular arrangement, for easy sending and receiving.
 

--- a/docs/networking/simpleimpl.md
+++ b/docs/networking/simpleimpl.md
@@ -11,10 +11,10 @@ First you need to create your `SimpleChannel` object. We recommend that you do t
 ```java
 private static final String PROTOCOL_VERSION = "1";
 public static final SimpleChannel INSTANCE = NetworkRegistry.newSimpleChannel(
-    new ResourceLocation("mymodid", "main"),
-    () -> PROTOCOL_VERSION,
-    PROTOCOL_VERSION::equals,
-    PROTOCOL_VERSION::equals
+  new ResourceLocation("mymodid", "main"),
+  () -> PROTOCOL_VERSION,
+  PROTOCOL_VERSION::equals,
+  PROTOCOL_VERSION::equals
 );
 ```
 
@@ -51,12 +51,12 @@ There are a couple things to highlight in a packet handler. A packet handler has
 
 ```java
 public static void handle(MyMessage msg, Supplier<NetworkEvent.Context> ctx) {
-    ctx.get().enqueueWork(() -> {
-        // Work that needs to be thread-safe (most work)
-        ServerPlayer sender = ctx.get().getSender(); // the client that sent this packet
-        // Do stuff
-    });
-    ctx.get().setPacketHandled(true);
+  ctx.get().enqueueWork(() -> {
+    // Work that needs to be thread-safe (most work)
+    ServerPlayer sender = ctx.get().getSender(); // the client that sent this packet
+    // Do stuff
+  });
+  ctx.get().setPacketHandled(true);
 }
 ```
 
@@ -65,16 +65,16 @@ Packets sent from the server to the client should be handled in another class an
 ```java
 // In Packet class
 public static void handle(MyClientMessage msg, Supplier<NetworkEvent.Context> ctx) {
-    ctx.get().enqueueWork(() ->
-        // Make sure it's only executed on the physical client
-        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> ClientPacketHandlerClass.handlePacket(msg, ctx))
-    );
-    ctx.get().setPacketHandled(true);
+  ctx.get().enqueueWork(() ->
+    // Make sure it's only executed on the physical client
+    DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> ClientPacketHandlerClass.handlePacket(msg, ctx))
+  );
+  ctx.get().setPacketHandled(true);
 }
 
 // In ClientPacketHandlerClass
 public static void handlePacket(MyClientMessage msg, Supplier<NetworkEvent.Context> ctx) {
-    // Do stuff
+  // Do stuff
 }
 ```
 

--- a/docs/rendering/modelloaders/itemoverrides.md
+++ b/docs/rendering/modelloaders/itemoverrides.md
@@ -21,21 +21,21 @@ Returns an immutable list containing all the [`BakedOverride`][override]s used b
 
 This class represents a vanilla item override, which holds several `ItemOverrides$PropertyMatcher` for the properties on an item and a model to use in case those matchers are satisfied. They are the objects in the `overrides` array of a vanilla item JSON model:
 
-```json
+```json5
 {
-  "__comment": "Inside a vanilla JSON item model.",
+  // Inside a vanilla JSON item model
   "overrides": [
     {
-      "__comment": "This is an ItemOverride.",
+      // This is an ItemOverride
       "predicate": {
-        "__comment": "This is the Map<ResourceLocation, Float>, containing the names of properties and their minimum values.",
+        // This is the Map<ResourceLocation, Float>, containing the names of properties and their minimum values
         "example1:prop": 0.5
       },
-      "__comment": "This is the 'location', or target model, of the override, which is used if the predicate above matches.",
+      // This is the 'location', or target model, of the override, which is used if the predicate above matches
       "model": "example1:item/model"
     },
     {
-      "__comment": "This is another ItemOverride.",
+      // This is another ItemOverride
       "predicate": {
         "example2:prop": 1
       },

--- a/docs/resources/client/models/itemproperties.md
+++ b/docs/resources/client/models/itemproperties.md
@@ -25,16 +25,16 @@ The format of an override can be seen on the [wiki][format], and a good example 
 !!! important
     A predicate applies to all values *greater than or equal to* the given value.
 
-```json
+```json5
 {
   "parent": "item/generated",
   "textures": {
-    "__comment": "Default",
+    // Default
     "layer0": "examplemod:items/example_partial"
   },
   "overrides": [
     {
-      "__comment": "power >= .75",
+      // power >= .75
       "predicate": {
         "examplemod:power": 0.75
       },

--- a/docs/resources/client/models/tinting.md
+++ b/docs/resources/client/models/tinting.md
@@ -16,7 +16,7 @@ If an item inherits from the `builtin/generated` model, each layer ("layer0", "l
 ```java
 @SubscribeEvent
 public void registerBlockColors(ColorHandlerEvent.Block event){
-    event.getBlockColors().register(myBlockColor, coloredBlock1, coloredBlock2, ...);
+  event.getBlockColors().register(myBlockColor, coloredBlock1, coloredBlock2, ...);
 }
 ```
 
@@ -25,7 +25,7 @@ public void registerBlockColors(ColorHandlerEvent.Block event){
 ```java
 @SubscribeEvent
 public void registerItemColors(ColorHandlerEvent.Item event){
-    event.getItemColors().register(myItemColor, coloredItem1, coloredItem2, ...);
+  event.getItemColors().register(myItemColor, coloredItem1, coloredItem2, ...);
 }
 ```
 

--- a/docs/resources/server/glm.md
+++ b/docs/resources/server/glm.md
@@ -9,20 +9,13 @@ Registering a Global Loot Modifier
 You will need 4 things:
 
 1. Create a `global_loot_modifiers.json`.
-
-    This will tell Forge about your modifiers and works similar to [tags].
-
+    * This will tell Forge about your modifiers and works similar to [tags].
 2. A serialized json representing your modifier.
-
-    This will contain all of the data about your modification and allows data packs to tweak your effect.
-
+    * This will contain all of the data about your modification and allows data packs to tweak your effect.
 3. A class that extends `IGlobalLootModifier`.
-
-    The operational code that makes your modifier work. Most modders can extend `LootModifier` as it supplies base functionality.
-
+    * The operational code that makes your modifier work. Most modders can extend `LootModifier` as it supplies base functionality.
 4. Finally, a class that extends `GlobalLootModifierSerializer` for your operational class.
-
-    This is [registered] as any other `IForgeRegistryEntry`.
+    * This is [registered] as any other `IForgeRegistryEntry`.
 
 The `global_loot_modifiers.json`
 -------------------------------
@@ -30,7 +23,6 @@ The `global_loot_modifiers.json`
 The `global_loot_modifiers.json` represents all loot modifiers to be loaded into the game. This file **MUST** be placed within `data/forge/loot_modifiers/global_loot_modifiers.json`.
 
 !!! important
-
     `global_loot_modifiers.json` will only be read in the `forge` namespace. The file will be neglected if it is under the mod's namespace.
 
 `entries` is an *ordered list* of the modifiers that will be loaded. The [ResourceLocation][resloc]s specified points to their associated entry within `data/<namespace>/loot_modifiers/<path>.json`. This is primarily relevant to data pack makers for resolving conflicts between modifiers from separate mods.
@@ -59,7 +51,6 @@ This file contains all of the potential variables related to your modifier, incl
 `conditions` should represent the loot table conditions for this modifier to activate. Conditions should avoid being hardcoded to allow datapack creators as much flexibility to adjust the criteria. This must also be always present.
 
 !!! important
-
     Although `conditions` should represent what is needed for the modifier to activate, this is only the case if using the bundled Forge classes. If using `LootModifier` as a subclass, all conditions will be **ANDed** together and checked to see if the modifier should be applied.
 
 Any additional properties read by the serializer and defined by the modifier can also be specified.
@@ -86,7 +77,6 @@ To supply the functionality a global loot modifier specifies, a `IGlobalLootModi
 There is only one method that needs to be defined in order to create a new modifier: `#apply`. This takes in the current loot that will be generated along with the context information such as the currently level or additional defined parameters. It returns the list of drops to generate.
 
 !!! note
-
     The returned list of drops from any one modifier is fed into other modifiers in the order they are registered. As such, modified loot can be modified by another loot modifier.
 
 ### The `LootModifier` Subclass
@@ -102,16 +92,16 @@ The `#doApply` method works the same as the `#apply` method except that it only 
 ```java
 public class ExampleModifier extends LootModifier {
 
-    public ExampleModifier(LootItemCondition[] conditionsIn, String prop1, int prop2, Item prop3) {
-        super(conditionsIn);
-        // Store the rest of the parameters
-    }
+  public ExampleModifier(LootItemCondition[] conditionsIn, String prop1, int prop2, Item prop3) {
+    super(conditionsIn);
+    // Store the rest of the parameters
+  }
 
-    @Nonnull
-    @Override
-    protected List<ItemStack> doApply(List<ItemStack> generatedLoot, LootContext context) {
-        // Modify the loot and return the new drops
-    }
+  @Nonnull
+  @Override
+  protected List<ItemStack> doApply(List<ItemStack> generatedLoot, LootContext context) {
+    // Modify the loot and return the new drops
+  }
 }
 ```
 
@@ -129,21 +119,21 @@ Two methods must be defined within the serializer implementation: `#read` and `#
 ```java
 public ExampleModifierSerializer extends GlobalLootModifierSerializer<ExampleModifier> {
 
-    @Override
-    public ExampleModifier read(ResourceLocation location, JsonObject object, LootItemCondition[] conditions) {
-        String prop1 = GsonHelper.getAsString(object, "prop1");
-        // Deserializer other properties
-        return new ExampleModifier(conditions, prop1, prop2, prop3);
-    }
+  @Override
+  public ExampleModifier read(ResourceLocation location, JsonObject object, LootItemCondition[] conditions) {
+    String prop1 = GsonHelper.getAsString(object, "prop1");
+    // Deserializer other properties
+    return new ExampleModifier(conditions, prop1, prop2, prop3);
+  }
 
-    @Override
-    public JsonObject write(ExampleModifier instance) {
-        // Create json object with conditions in modifier
-        JsonObject res = this.makeConditions(instance.conditionsIn);
-        res.addProperty("prop1", instance.prop1);
-        // Add other properties in modifier
-        return res;
-    }
+  @Override
+  public JsonObject write(ExampleModifier instance) {
+    // Create json object with conditions in modifier
+    JsonObject res = this.makeConditions(instance.conditionsIn);
+    res.addProperty("prop1", instance.prop1);
+    // Add other properties in modifier
+    return res;
+  }
 }
 
 ```

--- a/docs/resources/server/recipes.md
+++ b/docs/resources/server/recipes.md
@@ -14,29 +14,29 @@ A basic recipe file might look like the following example:
 
 ```json
 {
-    "type": "minecraft:crafting_shaped",
-    "pattern":
-    [
-        "xxa",
-        "x x",
-        "xxx"
-    ],
-    "key":
+  "type": "minecraft:crafting_shaped",
+  "pattern":
+  [
+    "xxa",
+    "x x",
+    "xxx"
+  ],
+  "key":
+  {
+    "x":
     {
-        "x":
-        {
-            "tag": "forge:gems/diamond"
-        },
-        "a":
-        {
-            "item": "mymod:myfirstitem"
-        }
+      "tag": "forge:gems/diamond"
     },
-    "result":
+    "a":
     {
-        "item": "mymod:myitem",
-        "count": 9
+      "item": "mymod:myfirstitem"
     }
+  },
+  "result":
+  {
+    "item": "mymod:myitem",
+    "count": 9
+  }
 }
 ```
 
@@ -72,16 +72,16 @@ To define a shapeless recipe, you have to use the `ingredients` list. It defines
 
 The following example shows how an ingredient list looks like within JSON:
 
-```json
-    "ingredients": [
-        {
-            "tag": "forge:gems/diamond"
-        },
-        {
-            "item": "minecraft:nether_star"
-        }
-    ],
-    ...
+```json5
+"ingredients": [
+  {
+    "tag": "forge:gems/diamond"
+  },
+  {
+    "item": "minecraft:nether_star"
+  }
+],
+// ...
 ```
 
 ### Results


### PR DESCRIPTION
Modifies the spacing to use 2 spaces as described in the convention. There are only two instances when this is not possible: combining ordered and unordered list entries and creating tabs for ordered lists.

Additionally, modifies the JSON snippets to use json5 if needed to express comments.