### PR TITLE
[1.18.x] Support JSON Highlighting with Comments

### DIFF
--- a/docs/concepts/internationalization.md
+++ b/docs/concepts/internationalization.md
@@ -12,7 +12,7 @@ Language files
 
 Language files are located by `assets/[namespace]/lang/[locale].json` (e.g. all US English translations provided by `examplemod` would be within `assets/examplemod/lang/en_us.json`). The file format is simply a json map from translation keys to values. The file must be encoded in UTF-8. Old .lang files can be converted to json using a [converter][converter].
 
-```json
+```js
 {
   "item.examplemod.example_item": "Example Item Name",
   "block.examplemod.example_block": "Example Block Name",
@@ -27,7 +27,7 @@ Block, Item and a few other Minecraft classes have built-in translation keys use
 
 By default, `#getDescriptionId` will return `block.` or `item.` prepended to the registry name of the block or item, with the colon replaced by a dot. `BlockItem`s override this method to take their corresponding `Block`'s translation key by default. For example, an item with ID `examplemod:example_item` effectively requires the following line in a language file:
 
-```json
+```js
 {
   "item.examplemod.example_item": "Example Item Name"
 }

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,6 +27,8 @@ Please use equals and dash underlines, instead of `#` and `##`. For h3 and lower
 
 When referencing fields and methods outside of code block snippets, they should use a `#` separator (e.g. `ClassName#methodName`). Inner classes should use a `$` separator (e.g. `ClassName$InnerClassName`).
 
+JSON code block snippets should use `js` syntax highlighting.
+
 All links should have their location specified at the bottom of the page. Any internal links should reference the page via their relative path.
 
 Admonitions (represented by `!!! <type>`) must be formatted as [documented][admonition]; otherwise they may end up rendering incorrectly.

--- a/docs/gameeffects/particles.md
+++ b/docs/gameeffects/particles.md
@@ -95,7 +95,7 @@ There are three particle render types that cannot use the above method of regist
 
 To add a texture to a particle, a new JSON file must be added to `assets/<modid>/particles`. This is known as the `ParticleDescription`. The name of this file will represent the registry name of the `ParticleType` the factory is being attached to. Each particle JSON is an object. The object stores a single key `textures` which holds an array of `ResourceLocation`s. Any `<modid>:<path>` texture represented here will point to a texture at `assets/<modid>/textures/particle/<path>.png`.
 
-```json5
+```js
 {
   "textures": [
     // Will point to a texture located in

--- a/docs/gameeffects/sounds.md
+++ b/docs/gameeffects/sounds.md
@@ -17,7 +17,7 @@ This JSON defines sound events, and defines which sound files they play, the sub
 
 A full specification is available on the vanilla [wiki][], but this example highlights the important parts:
 
-```json
+```js
 {
   "open_chest": {
     "subtitle": "mymod.subtitle.open_chest",

--- a/docs/misc/updatechecker.md
+++ b/docs/misc/updatechecker.md
@@ -13,7 +13,7 @@ Update JSON format
 
 The JSON itself has a relatively simple format as follows:
 
-```json5
+```js
 {
   "homepage": "<homepage/download page for your mod>",
   "<mcversion>": {

--- a/docs/rendering/modelloaders/index.md
+++ b/docs/rendering/modelloaders/index.md
@@ -8,7 +8,7 @@ WaveFront OBJ Models
 
 Forge adds a loader for the `.obj` file format. To use these models, the JSON must reference the `forge:obj` loader. This loader accepts any model location that is in a registered namespace and whose path ends in `.obj`. The `.mtl` file should be placed in the same location with the same name as the `.obj` to be used automatically. The `.mtl` file will probably have to be manually edited to change the paths pointing to textures defined within the JSON. Additionally, the V axis for textures may be flipped depending on the external program that created the model (i.e. V = 0 may be the bottom edge, not the top). This may be rectified in the modelling program itself or done in the model JSON like so:
 
-```json5
+```js
 {
   // Add the following line on the same level as a 'model' declaration
   "loader": "forge:obj",

--- a/docs/rendering/modelloaders/itemoverrides.md
+++ b/docs/rendering/modelloaders/itemoverrides.md
@@ -21,7 +21,7 @@ Returns an immutable list containing all the [`BakedOverride`][override]s used b
 
 This class represents a vanilla item override, which holds several `ItemOverrides$PropertyMatcher` for the properties on an item and a model to use in case those matchers are satisfied. They are the objects in the `overrides` array of a vanilla item JSON model:
 
-```json5
+```js
 {
   // Inside a vanilla JSON item model
   "overrides": [

--- a/docs/resources/client/models/itemproperties.md
+++ b/docs/resources/client/models/itemproperties.md
@@ -25,7 +25,7 @@ The format of an override can be seen on the [wiki][format], and a good example 
 !!! important
     A predicate applies to all values *greater than or equal to* the given value.
 
-```json5
+```js
 {
   "parent": "item/generated",
   "textures": {

--- a/docs/resources/server/conditional.md
+++ b/docs/resources/server/conditional.md
@@ -8,7 +8,7 @@ Implementations
 
 Currently, conditional loading is implemented for recipes and advancements. For any conditional recipe or advancement, a list of conditions to datum pair is loaded. If the conditions specified for a datum in the list is true, then that datum is returned. Otherwise, the datum is discarded.
 
-```json5
+```js
 {
   // The type needs to be specified for recipes as they can have custom serializers
   // Advancements do not need this type
@@ -48,7 +48,7 @@ Conditions are specified by setting `type` to the name of the condition as speci
 
 Boolean conditions consist of no data and return the expected value of the condition. They are represented by `forge:true` and `forge:false`.
 
-```json5
+```js
 // For some condition
 {
   // Will always return true (or false for 'forge:false')
@@ -61,7 +61,7 @@ Boolean conditions consist of no data and return the expected value of the condi
 Boolean operator conditions consist of the condition(s) being operated upon and apply the following logic. They are represented by `forge:not`, `forge:and`, and `forge:or`.
 
 
-```json5
+```js
 // For some condition
 {
   // Inverts the result of the stored condition
@@ -72,7 +72,7 @@ Boolean operator conditions consist of the condition(s) being operated upon and 
 }
 ```
 
-```json5
+```js
 // For some condition
 {
   // ANDs the stored conditions together (or ORs for 'forge:or')
@@ -92,7 +92,7 @@ Boolean operator conditions consist of the condition(s) being operated upon and 
 
 `ModLoadedCondition` returns true whenever the specified mod with the given id is loaded in the current application. This is represented by `forge:mod_loaded`.
 
-```json5
+```js
 // For some condition
 {
   "type": "forge:mod_loaded",
@@ -105,7 +105,7 @@ Boolean operator conditions consist of the condition(s) being operated upon and 
 
 `ItemExistsCondition` returns true whenever the given item has been registered in the current application. This is represented by `forge:item_exists`.
 
-```json5
+```js
 // For some condition
 {
   "type": "forge:item_exists",
@@ -118,7 +118,7 @@ Boolean operator conditions consist of the condition(s) being operated upon and 
 
 `TagEmptyCondition` returns true whenever the given item tag has no items within it. This is represented by `forge:tag_empty`.
 
-```json5
+```js
 // For some condition
 {
   "type": "forge:tag_empty",

--- a/docs/resources/server/glm.md
+++ b/docs/resources/server/glm.md
@@ -29,7 +29,7 @@ The `global_loot_modifiers.json` represents all loot modifiers to be loaded into
 
 `replace`, when `true`, changes the behavior from appending loot modifiers to the global list to replacing the global list entries entirely. Modders will want to use `false` for compatibility with other mod implementations. Datapack makers may want to specify their overrides with `true`.
 
-```json5
+```js
 {
   "replace": false, // Must be present
   "entries": [
@@ -55,7 +55,7 @@ This file contains all of the potential variables related to your modifier, incl
 
 Any additional properties read by the serializer and defined by the modifier can also be specified.
 
-```json5
+```js
 // Within data/examplemod/loot_modifiers/example_glm.json
 {
   "type": "examplemod:example_loot_modifier",

--- a/docs/resources/server/recipes/custom.md
+++ b/docs/resources/server/recipes/custom.md
@@ -88,7 +88,7 @@ Building the JSON
 
 Custom Recipe JSONs are stored in the same place as other [recipes][json]. The specified `type` should represent the registry name of the **recipe serializer**. Any additional data is specified by the serializer during decoding.
 
-```json5
+```js
 {
   // The custom serializer registry name
   "type": "examplemod:example_serializer",

--- a/docs/resources/server/recipes/index.md
+++ b/docs/resources/server/recipes/index.md
@@ -10,7 +10,7 @@ Most recipe implementations within vanilla are data driven via JSON. This means 
 
 A recipe can be obtained within the Recipe Book as a reward for completing an [advancement][advancement]. Recipe advancements always have `minecraft:recipes/root` as their parent, to not to appear on the advancement screen. The default criteria to gain the recipe advancement is a check if the user has unlocked the recipe from using it once or receiving it through a command like `/recipe`:
 
-```json5
+```js
 // Within some recipe advancement json
 "has_the_recipe": { // Criteria label
   // Succeeds if examplemod:example_recipe is used
@@ -59,7 +59,7 @@ Forge provides some additional behavior to the recipe schema and its implementat
 
 Except for `minecraft:stonecutting` recipes, all vanilla recipe serializers expand the `result` tag to take in a full `ItemStack` as a `JsonObject` instead of just the item name and amount in some cases.
 
-```json5
+```js
 // In some recipe JSON
 "result": {
   // The name of the registry item to give as a result

--- a/docs/resources/server/recipes/ingredients.md
+++ b/docs/resources/server/recipes/ingredients.md
@@ -16,7 +16,7 @@ Forge provides a few additional `Ingredient` types for programmers to implement.
 
 Though they are functionally identical, Compound ingredients replaces the way one would implement a list of ingredients would in a recipe. They work as a set OR where the passed in stack must be within at least one of the supplied ingredients. This change was made to allow custom ingredients to work correctly within lists. As such, **no type** needs to be specified.
 
-```json5
+```js
 // For some input
 [
   // At least one of these ingredients must match to succeed
@@ -34,7 +34,7 @@ Though they are functionally identical, Compound ingredients replaces the way on
 
 `NBTIngredient`s compare the item, damage, and the share tags (as defined by `IForgeItem#getShareTag`) on an `ItemStack` for exact equivalency. This can be used by specifying the `type` as `forge:nbt`.
 
-```json5
+```js
 // For some input
 {
   "type": "forge:nbt",
@@ -49,7 +49,7 @@ Though they are functionally identical, Compound ingredients replaces the way on
 
 `PartialNBTIngredient`s are a looser version of [`NBTIngredient`][nbt] as they compare against a single or set of items and only keys specified within the share tag (as defined by `IForgeItem#getShareTag`). This can be used by specifying the `type` as `forge:partial_nbt`.
 
-```json5
+```js
 // For some input
 {
   "type": "forge:partial_nbt",
@@ -78,7 +78,7 @@ Though they are functionally identical, Compound ingredients replaces the way on
 
 `IntersectionIngredient`s work as a set AND where the passed in stack must match all supplied ingredients. There must be at least two ingredients supplied to this. This can be used by specifying the `type` as `forge:intersection`.
 
-```json5
+```js
 // For some input
 {
   "type": "forge:intersection",
@@ -100,7 +100,7 @@ Though they are functionally identical, Compound ingredients replaces the way on
 
 `DifferenceIngredient`s work as a set subtraction (SUB) where the passed in stack must match the first ingredient but must not match the second ingredient. This can be used by specifying the `type` as `forge:difference`.
 
-```json5
+```js
 // For some input
 {
   "type": "forge:difference",

--- a/docs/resources/server/tags.md
+++ b/docs/resources/server/tags.md
@@ -11,7 +11,7 @@ For example, to add your own mod's saplings to the Vanilla sapling tag, you woul
 If `replace` is true, then all entries before the json specifying `replace` will be removed.
 Values listed that are not present will cause the tag to error unless the value is listed using an `id` string and `required` boolean set to false, as in the following example:
 
-```json
+```js
 {
   "replace": false,
   "values": [


### PR DESCRIPTION
Addresses #430

To address Highlight.js not supporting a syntax highligher with JSON comments, all JSON code blocks will use the JavaScript highlight. This does not cause any difference in the mkdocs highlight since keys and values are treated as the same color for highlighting with the theme.

Additionally, a contributing guideline is added for future additions.