### PR TITLE
[1.18.x] Update Data Generation

### DIFF
--- a/docs/datagen/client/modelproviders.md
+++ b/docs/datagen/client/modelproviders.md
@@ -4,14 +4,6 @@ The model providers are a specific type of data generators for defining models. 
 
 `ModelProvider` provides methods to define models for blocks and items alike: cubes, single textures, doors, slabs, and even custom non-data-generated models as parent models.
 
-Existing Files
---------------
-All references to textures or other data files not generated for data generation must reference existing files on the system. This is to ensure that all referenced textures are in the correct places, so typos can be found and corrected. 
-
-`ExistingFileHelper` is the class responsible for validating the existence of those data files. An instance can be retrieved from  `GatherDataEvent#getExistingFileHelper()`.
-
-The `--existing <folderpath>` argument allows the specified folder and its subfolders to be used when validating the existence of files. By default, only the vanilla datapack and resources are available to the `ExistingFileHelper`.
-
 Implementation
 --------------
 There are three main abstract implementations of `ModelProvider`: `ItemModelProvider`, `BlockModelProvider`, and `BlockStateProvider`.

--- a/docs/datagen/index.md
+++ b/docs/datagen/index.md
@@ -7,6 +7,14 @@ The data generator system is loaded by the main class `net.minecraft.data.Main`.
 
 The default configurations in the MDK `build.gradle` adds the `runData` task for running the data generators.
 
+Existing Files
+--------------
+All references to textures or other data files not generated for data generation must reference existing files on the system. This is to ensure that all referenced textures are in the correct places, so typos can be found and corrected. 
+
+`ExistingFileHelper` is the class responsible for validating the existence of those data files. An instance can be retrieved from  `GatherDataEvent#getExistingFileHelper`.
+
+The `--existing <folderpath>` argument allows the specified folder and its subfolders to be used when validating the existence of files. Additionally, the `--existing-mod <modid>` argument allows the resources of a loaded mod to be used for validation. By default, only the vanilla datapack and resources are available to the `ExistingFileHelper`.
+
 Generator Modes
 ---------------
 

--- a/docs/datagen/index.md
+++ b/docs/datagen/index.md
@@ -22,22 +22,23 @@ The data generator can be configured to run 4 different data generations, which 
 
 * __Client Assets__
   * Generates client-only files in `assets`: block/item models, blockstate JSONs, language files, etc.
-  * __`--client`__, `includeClient()`
+  * __`--client`__, `#includeClient`
 * __Server Data__
   * Generates server-only files in `data`: recipes, advancements, tags, etc.
-  * __`--server`__, `includeServer()`
+  * __`--server`__, `#includeServer`
 * __Development Tools__
   * Runs some development tools: converting SNBT to NBT and vice-versa, etc.
-  * __`--dev`__, `includeDev()`
+  * __`--dev`__, `#includeDev`
 * __Reports__
   * Dumps all registered blocks, items, commands, etc.
-  * __`--reports`__, `includeReports()`
+  * __`--reports`__, `#includeReports`
+
+All of the generators can be included using `--all`.
 
 Data Providers
 --------------
 
-Data providers are the classes that actually define what data will be generated and provided. All data providers implement `DataProvider`.
-Minecraft has abstract implementations for most assets and data, so modders need only to extend and override the specified method.
+Data providers are the classes that actually define what data will be generated and provided. All data providers implement `DataProvider`. Minecraft has abstract implementations for most assets and data, so modders need only to extend and override the specified method.
 
 The `GatherDataEvent` is fired on the mod event bus when the data generator is being created, and the `DataGenerator` can be obtained from the event. Create and register data providers using `DataGenerator#addProvider`.
 


### PR DESCRIPTION
This PR specifically targets the main datagen documentation and moves content (such as `ExistingFileHelper`) defined in a specific place to the main doc. Additionally, adds information on using resources from existing mods and generating all generators using --all.