### PR TITLE
[1.18.x] Migrate Dropdown to 1.19

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,8 +104,8 @@ theme:
 extra:
   current_version: 1.18.x
   versions:
-    1.16.x: 1.16.x
     1.18.x: 1.18.x
+    1.19.x: 1.19.x
 
 extra_css:
   - css/version_warning_fix.css


### PR DESCRIPTION
Simply migrates the dropdown menu to 1.19.x and 1.18.x for LTS.

Will create new branch for 1.19.x after PR.