### PR TITLE
[1.19.x] Update mcforge URLs to docs.minecraftforge.net

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
 # Contributing Documentation
 
-Guidelines for contributing can be found [on the docs](https://mcforge.readthedocs.io/en/latest/contributing/).
+Guidelines for contributing can be found [on the docs][contributing].
+
+[contributing]: https://docs.minecraftforge.net/en/latest/contributing/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Documentation
-This is the official MinecraftForge documentation, located at https://mcforge.readthedocs.org.
+This is the official MinecraftForge documentation, located at https://docs.minecraftforge.net.
 
 It is intended to provide detailed documentation of Forge development concepts. This does not include javadocs.
 

--- a/docs/legacy/index.md
+++ b/docs/legacy/index.md
@@ -12,13 +12,13 @@ Unfortunately, not all versions were used for a significant amount of time, and 
 
 |    Version    |  Accuracy  |                  Link                     |
 |:-------------:|:----------:|:------------------------------------------|
-|    1.12.x     |   100%     | https://mcforge.readthedocs.io/en/1.12.x/ |
-|    1.13.x     |    10%     | https://mcforge.readthedocs.io/en/1.13.x/ |
-|    1.14.x     |    10%     | https://mcforge.readthedocs.io/en/1.14.x/ |
-|    1.15.x     |    85%     | https://mcforge.readthedocs.io/en/1.15.x/ |
-|    1.16.x     |    85%     | https://mcforge.readthedocs.io/en/1.16.x/ |
-|    1.17.x     |    85%     | https://mcforge.readthedocs.io/en/1.17.x/ |
-|    1.18.x     |    90%     | https://mcforge.readthedocs.io/en/1.18.x/ |
+|    1.12.x     |   100%     | https://docs.minecraftforge.net/en/1.12.x/ |
+|    1.13.x     |    10%     | https://docs.minecraftforge.net/en/1.13.x/ |
+|    1.14.x     |    10%     | https://docs.minecraftforge.net/en/1.14.x/ |
+|    1.15.x     |    85%     | https://docs.minecraftforge.net/en/1.15.x/ |
+|    1.16.x     |    85%     | https://docs.minecraftforge.net/en/1.16.x/ |
+|    1.17.x     |    85%     | https://docs.minecraftforge.net/en/1.17.x/ |
+|    1.18.x     |    90%     | https://docs.minecraftforge.net/en/1.18.x/ |
 
 ### RetroGradle
 

--- a/forge_theme/base.html
+++ b/forge_theme/base.html
@@ -88,7 +88,7 @@
                         <label for="version-selection-dropdown">Version:</label>
                         <select id="version-selection-dropdown" class="version-selection-dropdown" onchange="location = this.value;">
                             {% for name, url in config.extra.versions.items() %}
-                            <option value="https://mcforge.readthedocs.io/en/{{ url }}" {% if name == config.extra.current_version %}selected{% endif %}>{{ name }}</option>
+                            <option value="https://docs.minecraftforge.net/en/{{ url }}" {% if name == config.extra.current_version %}selected{% endif %}>{{ name }}</option>
                             {% endfor %}
                         </select>
                     </form>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,7 +87,7 @@ nav:
 
 # Do not edit in PRs below here
 site_name: Forge Documentation
-site_url: https://mcforge.readthedocs.io/en/1.19.x/
+site_url: https://docs.minecraftforge.net/en/1.19.x/
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Updates the docs links to use the new URL of where the docs are hosted.