### PR TITLE
[1.19.x] Fix KeyMapping registration code

### DIFF
--- a/docs/misc/keymappings.md
+++ b/docs/misc/keymappings.md
@@ -13,7 +13,7 @@ A `KeyMapping` can be registered by listening to the `RegisterKeyMappingsEvent` 
 public static final Lazy<KeyMapping> EXAMPLE_MAPPING = Lazy.of(() -> /*...*/);
 
 // Event is on the mod event bus only on the physical client
-public void registerBindings(RegisterKeyBindingsEvent event) {
+public void registerBindings(RegisterKeyMappingsEvent event) {
   event.register(EXAMPLE_MAPPING.get());
 }
 ```

--- a/docs/misc/keymappings.md
+++ b/docs/misc/keymappings.md
@@ -13,6 +13,7 @@ A `KeyMapping` can be registered by listening to the `RegisterKeyMappingsEvent` 
 public static final Lazy<KeyMapping> EXAMPLE_MAPPING = Lazy.of(() -> /*...*/);
 
 // Event is on the mod event bus only on the physical client
+@SubscribeEvent
 public void registerBindings(RegisterKeyMappingsEvent event) {
   event.register(EXAMPLE_MAPPING.get());
 }


### PR DESCRIPTION
This PR fixes the code example for registering a KeyMapping, by replacing ``RegisterKeyBindingsEvent`` with ``RegisterKeyMappingsEvent`` and adds the ``@SubscribeEvent`` annotation