### PR TITLE
[1.19.x] Datapack Registry Object Providers

### DIFF
--- a/docs/datagen/index.md
+++ b/docs/datagen/index.md
@@ -55,7 +55,7 @@ The `GatherDataEvent` is fired on the mod event bus when the data generator is b
 **These classes are under the `net.minecraftforge.common.data` package**:
 
 * [`GlobalLootModifierProvider`][glmgen] - for [global loot modifiers][glm]; implement `#start`
-* [`DatapackBuiltinEntriesProvider`][dynamicregistriesgen] for dynamic registry objects; pass in `RegistrySetBuilder` to the constructor
+* [`DatapackBuiltinEntriesProvider`][datapackregistriesgen] for datapack registry objects; pass in `RegistrySetBuilder` to the constructor
 
 **These classes are under the `net.minecraft.data` package**:
 
@@ -75,7 +75,7 @@ The `GatherDataEvent` is fired on the mod event bus when the data generator is b
 [blockstategen]: ./client/modelproviders.md#block-state-provider
 [glmgen]: ./server/glm.md
 [glm]: ../resources/server/glm.md
-[dynamicregistriesgen]: ./server/dynamicregistries.md
+[datapackregistriesgen]: ./server/datapackregistries.md
 [loottablegen]: ./server/loottables.md
 [loottable]: ../resources/server/loottables.md
 [recipegen]: ./server/recipes.md

--- a/docs/datagen/index.md
+++ b/docs/datagen/index.md
@@ -51,8 +51,14 @@ The `GatherDataEvent` is fired on the mod event bus when the data generator is b
 * [`net.minecraftforge.client.model.generators.BlockStateProvider`][blockstategen] - for blockstate JSONs and their block and item models; implement `#registerStatesAndModels`
 
 ### Server Data
-* [`net.minecraftforge.common.data.GlobalLootModifierProvider`][glmgen] - for [global loot modifiers][glm]; implement `#start`
-* _These classes are under the `net.minecraft.data` package_
+
+**These classes are under the `net.minecraftforge.common.data` package**:
+
+* [`GlobalLootModifierProvider`][glmgen] - for [global loot modifiers][glm]; implement `#start`
+* [`DatapackBuiltinEntriesProvider`][dynamicregistriesgen] for dynamic registry objects; pass in `RegistrySetBuilder` to the constructor
+
+**These classes are under the `net.minecraft.data` package**:
+
 * [`loot.LootTableProvider`][loottablegen] - for [loot tables][loottable]; pass in `LootTableProvider$SubProviderEntry`s to the constructor
 * [`recipes.RecipeProvider`][recipegen] - for [recipes] and their unlocking advancements; implement `#buildRecipes`
 * [`tags.TagsProvider`][taggen] - for [tags]; implement `#addTags`
@@ -69,6 +75,7 @@ The `GatherDataEvent` is fired on the mod event bus when the data generator is b
 [blockstategen]: ./client/modelproviders.md#block-state-provider
 [glmgen]: ./server/glm.md
 [glm]: ../resources/server/glm.md
+[dynamicregistriesgen]: ./server/dynamicregistries.md
 [loottablegen]: ./server/loottables.md
 [loottable]: ../resources/server/loottables.md
 [recipegen]: ./server/recipes.md

--- a/docs/datagen/server/datapackregistries.md
+++ b/docs/datagen/server/datapackregistries.md
@@ -1,10 +1,10 @@
-Dynamic Registry Object Generation
+Datapack Registry Object Generation
 ==================================
 
-Dynamic registry objects can be generated for a mod by constructing a new `DatapackBuiltinEntriesProvider` and providing a `RegistrySetBuilder` with the new objects to register. The provider must be [added][datagen] to the `DataGenerator`.
+Datapack registry objects can be generated for a mod by constructing a new `DatapackBuiltinEntriesProvider` and providing a `RegistrySetBuilder` with the new objects to register. The provider must be [added][datagen] to the `DataGenerator`.
 
 !!! note
-    `DatapackBuiltinEntriesProvider` is a Forge extension on top of `RegistriesDatapackGenerator` which properly handles referencing existing dynamic registry objects without exploding the entry. So, this documentation will use `DatapackBuiltinEntriesProvider`.
+    `DatapackBuiltinEntriesProvider` is a Forge extension on top of `RegistriesDatapackGenerator` which properly handles referencing existing datapack registry objects without exploding the entry. So, this documentation will use `DatapackBuiltinEntriesProvider`.
 
 ```java
 // On the MOD event bus
@@ -16,9 +16,9 @@ public void gatherData(GatherDataEvent event) {
         output -> new DatapackBuiltinEntriesProvider(
           output,
           event.getLookupProvider(),
-          // The builder containing the dynamic registry objects to generate
+          // The builder containing the datapack registry objects to generate
           new RegistrySetBuilder().add(/* ... */),
-          // Set of mod ids to generate the dynamic registry objects of
+          // Set of mod ids to generate the datapack registry objects of
           Set.of(MOD_ID)
         )
     );
@@ -28,7 +28,7 @@ public void gatherData(GatherDataEvent event) {
 `RegistrySetBuilder`
 --------------------
 
-A `RegistrySetBuilder` is responsible for building all dynamic registry objects to be used within the game. The builder can add a new entry for a registry, which can then register objects to that registry.
+A `RegistrySetBuilder` is responsible for building all datapack registry objects to be used within the game. The builder can add a new entry for a registry, which can then register objects to that registry.
 
 First, a new instance of a `RegistrySetBuilder` can be initialized by calling the constructor. Then, the `#add` method (which takes in the `ResourceKey` of the registry, a `RegistryBootstrap` consumer containing the `BootstapContext` to register the objects, and an optional `Lifecycle` argument to indicate the registry's current lifecycle status) can be called to handle a specific registry for registration.
 
@@ -45,7 +45,7 @@ new RegistrySetBuilder()
 ```
 
 !!! note
-    Dynamic registries created through Forge can also generate their objects using this builder by also passing in the associated `ResourceKey`.
+    Datapack registries created through Forge can also generate their objects using this builder by also passing in the associated `ResourceKey`.
 
 Registering with `BootstapContext`
 ----------------------------------
@@ -69,7 +69,7 @@ new RegistrySetBuilder()
       new ConfiguredFeature<>(
         Feature.ORE, // Create an ore feature
         new OreConfiguration(
-          Collections.emptyList(), // Does nothing
+          List.of(), // Does nothing
           8 // in veins of at most 8
         )
       )
@@ -81,9 +81,9 @@ new RegistrySetBuilder()
   });
 ```
 
-### Dynamic Registry Object Lookup
+### Datapack Registry Object Lookup
 
-Sometimes dynamic registry objects may want to use other dynamic registry objects or tags containing dynamic registry objects. In those cases, you can look up another dynamic registry using `BootstapContext#lookup` to get a `HolderGetter`. From there, you can get a `Holder$Reference` to the dynamic registry object or a `HolderSet$Named` for the tag via `#getOrThrow` by passing in the associated key.
+Sometimes datapack registry objects may want to use other datapack registry objects or tags containing datapack registry objects. In those cases, you can look up another datapack registry using `BootstapContext#lookup` to get a `HolderGetter`. From there, you can get a `Holder$Reference` to the datapack registry object or a `HolderSet$Named` for the tag via `#getOrThrow` by passing in the associated key.
 
 ```java
 public static final ResourceKey<ConfiguredFeature<?, ?>> EXAMPLE_CONFIGURED_FEATURE = ResourceKey.create(
@@ -119,7 +119,7 @@ new RegistrySetBuilder()
       EXAMPLE_PLACED_FEATURE,
       new PlacedFeature(
         configured.getOrThrow(EXAMPLE_CONFIGURED_FEATURE), // Get the configured feature
-        Collections.emptyList() // and do nothing to the placement location
+        List.of() // and do nothing to the placement location
       )
     )
   });

--- a/docs/datagen/server/dynamicregistries.md
+++ b/docs/datagen/server/dynamicregistries.md
@@ -1,0 +1,128 @@
+Dynamic Registry Object Generation
+==================================
+
+Dynamic registry objects can be generated for a mod by constructing a new `DatapackBuiltinEntriesProvider` and providing a `RegistrySetBuilder` with the new objects to register. The provider must be [added][datagen] to the `DataGenerator`.
+
+!!! note
+    `DatapackBuiltinEntriesProvider` is a Forge extension on top of `RegistriesDatapackGenerator` which properly handles referencing existing dynamic registry objects without exploding the entry. So, this documentation will use `DatapackBuiltinEntriesProvider`.
+
+```java
+// On the MOD event bus
+@SubscribeEvent
+public void gatherData(GatherDataEvent event) {
+    event.getGenerator().addProvider(
+        // Tell generator to run only when server data are generating
+        event.includeServer(),
+        output -> new DatapackBuiltinEntriesProvider(
+          output,
+          event.getLookupProvider(),
+          // The builder containing the dynamic registry objects to generate
+          new RegistrySetBuilder().add(/* ... */),
+          // Set of mod ids to generate the dynamic registry objects of
+          Set.of(MOD_ID)
+        )
+    );
+}
+```
+
+`RegistrySetBuilder`
+--------------------
+
+A `RegistrySetBuilder` is responsible for building all dynamic registry objects to be used within the game. The builder can add a new entry for a registry, which can then register objects to that registry.
+
+First, a new instance of a `RegistrySetBuilder` can be initialized by calling the constructor. Then, the `#add` method can be called to handle a specific registry for registration. The `#add` method takes in the `ResourceKey` of the registry, a `RegistryBootstrap` consumer containing the `BootstapContext` to register the objects, and an optional `Lifecycle` argument to indicate the registry's current lifecycle status.
+
+```java
+new RegistrySetBuilder()
+  // Create configured features
+  .add(Registries.CONFIGURED_FEATURE, bootstrap -> {
+    // Register configured features here
+  })
+  // Create placed features
+  .add(Registries.PLACED_FEATURE, bootstrap -> {
+    // Register placed features here
+  });
+```
+
+!!! note
+    Dynamic registries created through Forge can also generate their objects using this builder by also passing in the associated `ResourceKey`.
+
+Registering with `BootstapContext`
+----------------------------------
+
+The `BootstapContext` provided by the builder can be used to register an object by calling the `#register` method. The `#register` method takes in the `ResourceKey` representing the registry name of the object, the object to register, and an optional `Lifecycle` argument to indicate the registry object's current lifecycle status.
+
+```java
+public static final ResourceKey<ConfiguredFeature<?, ?>> EXAMPLE_CONFIGURED_FEATURE = ResourceKey.create(
+  Registries.CONFIGURED_FEATURE,
+  new ResourceLocation(MOD_ID, "example_configured_feature")
+);
+
+// In some constant location or argument
+new RegistrySetBuilder()
+  // Create configured features
+  .add(Registries.CONFIGURED_FEATURE, bootstrap -> {
+    // Register configured features here
+    bootstrap.register(
+      // The resource key for the configured feature
+      EXAMPLE_CONFIGURED_FEATURE,
+      new ConfiguredFeature<>(
+        Feature.ORE, // Create an ore feature
+        new OreConfiguration(
+          Collections.emptyList(), // Does nothing
+          8 // in veins of at most 8
+        )
+      )
+    );
+  })
+  // Create placed features
+  .add(Registries.PLACED_FEATURE, bootstrap -> {
+    // Register placed features here
+  });
+```
+
+### Dynamic Registry Object Lookup
+
+Sometimes dynamic registry objects may want to use other dynamic registry objects or tags containing dynamic registry objects. In those cases, you can look up another dynamic registry using `BootstapContext#lookup` to get a `HolderGetter`. From there, you can get a `Holder$Reference` to the dynamic registry object or a `HolderSet$Named` for the tag via `#getOrThrow` by passing in the associated key.
+
+```java
+public static final ResourceKey<ConfiguredFeature<?, ?>> EXAMPLE_CONFIGURED_FEATURE = ResourceKey.create(
+  Registries.CONFIGURED_FEATURE,
+  new ResourceLocation(MOD_ID, "example_configured_feature")
+);
+
+public static final ResourceKey<PlacedFeature> EXAMPLE_PLACED_FEATURE = ResourceKey.create(
+  Registries.PLACED_FEATURE,
+  new ResourceLocation(MOD_ID, "example_placed_feature")
+);
+
+// In some constant location or argument
+new RegistrySetBuilder()
+  // Create configured features
+  .add(Registries.CONFIGURED_FEATURE, bootstrap -> {
+    // Register configured features here
+    bootstrap.register(
+      // The resource key for the configured feature
+      EXAMPLE_CONFIGURED_FEATURE,
+      new ConfiguredFeature(/* ... */)
+    );
+  })
+  // Create placed features
+  .add(Registries.PLACED_FEATURE, bootstrap -> {
+    // Register placed features here
+
+    // Get configured feature registry
+    HolderGetter<ConfiguredFeature<?, ?>> configured = bootstrap.lookup(Registries.CONFIGURED_FEATURE);
+
+    bootstrap.register(
+      // The resource key for the placed feature
+      EXAMPLE_PLACED_FEATURE,
+      new PlacedFeature(
+        configured.getOrThrow(EXAMPLE_CONFIGURED_FEATURE), // Get the configured feature
+        Collections.emptyList() // and do nothing to the placement location
+      )
+    )
+  });
+```
+
+[datagen]: ../index.md#data-providers

--- a/docs/datagen/server/dynamicregistries.md
+++ b/docs/datagen/server/dynamicregistries.md
@@ -30,7 +30,7 @@ public void gatherData(GatherDataEvent event) {
 
 A `RegistrySetBuilder` is responsible for building all dynamic registry objects to be used within the game. The builder can add a new entry for a registry, which can then register objects to that registry.
 
-First, a new instance of a `RegistrySetBuilder` can be initialized by calling the constructor. Then, the `#add` method can be called to handle a specific registry for registration. The `#add` method takes in the `ResourceKey` of the registry, a `RegistryBootstrap` consumer containing the `BootstapContext` to register the objects, and an optional `Lifecycle` argument to indicate the registry's current lifecycle status.
+First, a new instance of a `RegistrySetBuilder` can be initialized by calling the constructor. Then, the `#add` method (which takes in the `ResourceKey` of the registry, a `RegistryBootstrap` consumer containing the `BootstapContext` to register the objects, and an optional `Lifecycle` argument to indicate the registry's current lifecycle status) can be called to handle a specific registry for registration.
 
 ```java
 new RegistrySetBuilder()
@@ -50,7 +50,7 @@ new RegistrySetBuilder()
 Registering with `BootstapContext`
 ----------------------------------
 
-The `BootstapContext` provided by the builder can be used to register an object by calling the `#register` method. The `#register` method takes in the `ResourceKey` representing the registry name of the object, the object to register, and an optional `Lifecycle` argument to indicate the registry object's current lifecycle status.
+The `#register` method in the `BootstapContext` provided by the builder can be used to register objects. It takes in the `ResourceKey` representing the registry name of the object, the object to register, and an optional `Lifecycle` argument to indicate the registry object's current lifecycle status. 
 
 ```java
 public static final ResourceKey<ConfiguredFeature<?, ?>> EXAMPLE_CONFIGURED_FEATURE = ResourceKey.create(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
       - Tag Providers: 'datagen/server/tags.md'
       - Advancement Providers: 'datagen/server/advancements.md'
       - Global Loot Modifier Providers: 'datagen/server/glm.md'
+      - Dynamic Registry Object Providers: 'datagen/server/dynamicregistries.md'
   - Miscellaneous Features:
     - Configuration: 'misc/config.md'
     - Key Mappings: 'misc/keymappings.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,7 +73,7 @@ nav:
       - Tag Providers: 'datagen/server/tags.md'
       - Advancement Providers: 'datagen/server/advancements.md'
       - Global Loot Modifier Providers: 'datagen/server/glm.md'
-      - Dynamic Registry Object Providers: 'datagen/server/dynamicregistries.md'
+      - Datapack Registry Object Providers: 'datagen/server/datapackregistries.md'
   - Miscellaneous Features:
     - Configuration: 'misc/config.md'
     - Key Mappings: 'misc/keymappings.md'


### PR DESCRIPTION
Adds the documentation on how to register datapack registry objects. Not much else to say.