### PR TITLE
[1.19.x] Add ForgeGradle Typing to Documentation

### DIFF
--- a/forge_theme/base.html
+++ b/forge_theme/base.html
@@ -85,6 +85,16 @@
                 <h2 class="sidebar-heading">
                     <a href="#" class="close-sidebar"><i class="fa fa-bars"></i></a> Navigation
                     <form class="version-selection">
+                        <label for="version-selection-dropdown">Docs:</label>
+                        <select id="version-selection-dropdown" class="version-selection-dropdown" onchange="location = this.value;">
+                            {% for name, url in config.extra.types.items() %}
+                            <option value="https://docs.minecraftforge.net/en/{{ url }}" {% if name == config.extra.current_type %}selected{% endif %}>{{ name }}</option>
+                            {% endfor %}
+                        </select>
+                    </form>
+                </h2>
+                <h2 class="sidebar-heading">
+                    <form class="version-selection">
                         <label for="version-selection-dropdown">Version:</label>
                         <select id="version-selection-dropdown" class="version-selection-dropdown" onchange="location = this.value;">
                             {% for name, url in config.extra.versions.items() %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,10 @@ theme:
   custom_dir: forge_theme
 
 extra:
+  current_type: MinecraftForge
+  types:
+    MinecraftForge: latest
+    ForgeGradle: FG/6.x
   current_version: 1.19.x
   versions:
     1.18.x: 1.18.x


### PR DESCRIPTION
Adds to the navigation bar the ability to choose whether to view MinecraftForge or ForgeGradle docs.