### PR TITLE
[1.19.2] Add ForgeGradle Typing to Documentation

### DIFF
--- a/docs/blocks/states.md
+++ b/docs/blocks/states.md
@@ -50,18 +50,18 @@ Implementing Block States
 In your Block class, create or reference `static final` `Property<?>` objects for every property that your Block has. You are free to make your own `Property<?>` implementations, but the means to do that are not covered in this article. The vanilla code provides several convenience implementations:
 
 * `IntegerProperty`
-  * Implements `Property<Integer>`. Defines a property that holds an integer value.
-  * Created by calling `IntegerProperty#create(String propertyName, int minimum, int maximum)`.
+    * Implements `Property<Integer>`. Defines a property that holds an integer value.
+    * Created by calling `IntegerProperty#create(String propertyName, int minimum, int maximum)`.
 * `BooleanProperty`
-  * Implements `Property<Boolean>`. Defines a property that holds a `true` or `false` value.
-  * Created by calling `BooleanProperty#create(String propertyName)`.
+    * Implements `Property<Boolean>`. Defines a property that holds a `true` or `false` value.
+    * Created by calling `BooleanProperty#create(String propertyName)`.
 * `EnumProperty<E extends Enum<E>>`
-  * Implements `Property<E>`. Defines a property that can take on the values of an Enum class.
-  * Created by calling `EnumProperty#create(String propertyName, Class<E> enumClass)`.
-  * It is also possible to use only a subset of the Enum values (e.g. 4 out of 16 `DyeColor`s). See the overloads of `EnumProperty#create`.
+    * Implements `Property<E>`. Defines a property that can take on the values of an Enum class.
+    * Created by calling `EnumProperty#create(String propertyName, Class<E> enumClass)`.
+    * It is also possible to use only a subset of the Enum values (e.g. 4 out of 16 `DyeColor`s). See the overloads of `EnumProperty#create`.
 * `DirectionProperty`
-  * This is a convenience implementation of `EnumProperty<Direction>`
-  * Several convenience predicates are also provided. For example, to get a property that represents the cardinal directions, call `DirectionProperty.create("<name>", Direction.Plane.HORIZONTAL)`; to get the X directions, `DirectionProperty.create("<name>", Direction.Axis.X)`.
+    * This is a convenience implementation of `EnumProperty<Direction>`
+    * Several convenience predicates are also provided. For example, to get a property that represents the cardinal directions, call `DirectionProperty.create("<name>", Direction.Plane.HORIZONTAL)`; to get the X directions, `DirectionProperty.create("<name>", Direction.Axis.X)`.
 
 The class `BlockStateProperties` contains shared vanilla properties which should be used or referenced whenever possible, in place of creating your own properties.
 

--- a/docs/misc/keymappings.md
+++ b/docs/misc/keymappings.md
@@ -13,7 +13,8 @@ A `KeyMapping` can be registered by listening to the `RegisterKeyMappingsEvent` 
 public static final Lazy<KeyMapping> EXAMPLE_MAPPING = Lazy.of(() -> /*...*/);
 
 // Event is on the mod event bus only on the physical client
-public void registerBindings(RegisterKeyBindingsEvent event) {
+@SubscribeEvent
+public void registerBindings(RegisterKeyMappingsEvent event) {
   event.register(EXAMPLE_MAPPING.get());
 }
 ```

--- a/forge_theme/base.html
+++ b/forge_theme/base.html
@@ -85,6 +85,16 @@
                 <h2 class="sidebar-heading">
                     <a href="#" class="close-sidebar"><i class="fa fa-bars"></i></a> Navigation
                     <form class="version-selection">
+                        <label for="version-selection-dropdown">Docs:</label>
+                        <select id="version-selection-dropdown" class="version-selection-dropdown" onchange="location = this.value;">
+                            {% for name, url in config.extra.types.items() %}
+                            <option value="https://docs.minecraftforge.net/en/{{ url }}" {% if name == config.extra.current_type %}selected{% endif %}>{{ name }}</option>
+                            {% endfor %}
+                        </select>
+                    </form>
+                </h2>
+                <h2 class="sidebar-heading">
+                    <form class="version-selection">
                         <label for="version-selection-dropdown">Version:</label>
                         <select id="version-selection-dropdown" class="version-selection-dropdown" onchange="location = this.value;">
                             {% for name, url in config.extra.versions.items() %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,7 +90,7 @@ nav:
 
 # Do not edit in PRs below here
 site_name: Forge Documentation
-site_url: https://docs.minecraftforge.net/en/1.19.x/
+site_url: https://docs.minecraftforge.net/en/1.19.2/
 
 markdown_extensions:
   - admonition
@@ -107,9 +107,10 @@ theme:
   custom_dir: forge_theme
 
 extra:
-  current_version: 1.19.x
+  current_version: 1.19.2
   versions:
     1.18.x: 1.18.x
+    1.19.2: 1.19.2
     1.19.x: 1.19.x
 
 extra_css:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,10 @@ theme:
   custom_dir: forge_theme
 
 extra:
+  current_type: MinecraftForge
+  types:
+    MinecraftForge: latest
+    ForgeGradle: FG/6.x
   current_version: 1.19.2
   versions:
     1.18.x: 1.18.x


### PR DESCRIPTION
Adds to the navigation bar the ability to choose whether to view MinecraftForge or ForgeGradle docs.