### PR TITLE
Clarify src folder required to get started

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,8 @@
 Contributing to This Documentation
 ==================================
 
+Contribute to this documentation at [GitHub].
+
 This documentation is meant to be explanatory. Please explain how to do things, and break it down into reasonable chunks.
 We have a wiki elsewhere that can capture more comprehensive code examples.
 
@@ -33,4 +35,5 @@ All links should have their location specified at the bottom of the page. Any in
 
 Admonitions (represented by `!!! <type>`) must be formatted as [documented][admonition]; otherwise they may end up rendering incorrectly.
 
+[GitHub]: https://github.com/MinecraftForge/Documentation
 [admonition]: https://python-markdown.github.io/extensions/admonition/

--- a/docs/gettingstarted/index.md
+++ b/docs/gettingstarted/index.md
@@ -14,7 +14,7 @@ From Zero to Modding
     * `gradlew`
     * `settings.gradle`
     * the `gradle` folder
-4. Move the files listed above to a new folder. This will be your mod project folder.
+4. Copy the files listed above, and the example `src` folder, to a new folder. This will be your mod project folder.
 5. Choose your IDE:
     * Forge only explicitly supports developing with Eclipse, but there are additional run tasks for IntelliJ IDEA or Visual Studio Code environments. However, any environment, from Netbeans to vim/emacs, can be made to work.
     * For both Intellij IDEA and Eclipse, their Gradle integration will handle the rest of the initial workspace setup. This includes downloading packages from Mojang, MinecraftForge, and a few other software sharing sites. For VSCode, the 'Gradle Tasks' plugin can be used to handle the initial workspace setup.


### PR DESCRIPTION
Explicitly stating to include the example src folder, or the test run step later does not work.
