### PR TITLE
[1.18.x] Remove 1.19.2 from available versions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,7 +109,6 @@ extra:
   current_version: 1.18.x
   versions:
     1.18.x: 1.18.x
-    1.19.2: 1.19.2
     1.19.x: 1.19.x
 
 extra_css:


### PR DESCRIPTION
Closes #495

Removes 1.19.2 from 1.18.x as currently only 1.19.x (latest) and 1.18.x (LTS) are supported by the docs.