### PR TITLE
[1.19.x] Change Versions Displayed on Docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,8 +121,8 @@ extra:
     ForgeGradle: fg-6.x
   current_version: 1.19.x
   versions:
-    1.18.x: 1.18.x
     1.19.x: 1.19.x
+    1.20.x: 1.20.x
 
 extra_css:
   - css/version_warning_fix.css


### PR DESCRIPTION
This *would* change the version to latest and LTS, but as we don't know what those are yet, I'm just assuming 1.19.x and 1.20.x until there is a decision.