### PR TITLE
[1.19.x] correct the spelling of one word within events.md

### DIFF
--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -7,7 +7,7 @@ Example: An event can be used to perform an action when a Vanilla stick is right
 
 The main event bus used for most events is located at `MinecraftForge#EVENT_BUS`. There is another event bus for mod specific events located at `FMLJavaModLoadingContext#getModEventBus` that you should only use in specific cases. More information about this bus can be found below.
 
-Every event is fired on one of these busses: most events are fired on the main forge event bus, but some are fired on the mod specific event buses.
+Every event is fired on one of these buses: most events are fired on the main forge event bus, but some are fired on the mod specific event buses.
 
 An event handler is some method that has been registered to an event bus.
 


### PR DESCRIPTION
The word "busses" is invalid since the plural form of "bus" is only "buses", "busses" should be the third-person singular of "bus" but not the plural form of it. Consequently correct the mistake.