### PR TITLE
[1.19.x] improve an expression within items/index.md

### DIFF
--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -7,7 +7,7 @@ Example: An event can be used to perform an action when a Vanilla stick is right
 
 The main event bus used for most events is located at `MinecraftForge#EVENT_BUS`. There is another event bus for mod specific events located at `FMLJavaModLoadingContext#getModEventBus` that you should only use in specific cases. More information about this bus can be found below.
 
-Every event is fired on one of these busses: most events are fired on the main forge event bus, but some are fired on the mod specific event buses.
+Every event is fired on one of these buses: most events are fired on the main forge event bus, but some are fired on the mod specific event buses.
 
 An event handler is some method that has been registered to an event bus.
 

--- a/docs/items/index.md
+++ b/docs/items/index.md
@@ -26,7 +26,7 @@ Setting the properties of an item as above only works for simple items. If you w
 
 ## `CreativeModeTabEvent`
 
-An item can be added to a `CreativeModeTab` via `CreativeModeTabEvent$BuildContents` on the [mod event bus][modbus]. An item(s) can be added without any additional configurations via `#accept`.
+An item can be added to a `CreativeModeTab` via `CreativeModeTabEvent$BuildContents` on the [mod event bus][modbus]. An item or multiple items can be added without any additional configurations via `#accept`.
 
 ```java
 // Registered on the MOD event bus

--- a/docs/items/index.md
+++ b/docs/items/index.md
@@ -26,7 +26,7 @@ Setting the properties of an item as above only works for simple items. If you w
 
 ## `CreativeModeTabEvent`
 
-An item can be added to a `CreativeModeTab` via `CreativeModeTabEvent$BuildContents` on the [mod event bus][modbus]. An item or multiple items can be added without any additional configurations via `#accept`.
+An item can be added to a `CreativeModeTab` via `CreativeModeTabEvent$BuildContents` on the [mod event bus][modbus]. Items can be added without any additional configurations via `#accept`.
 
 ```java
 // Registered on the MOD event bus


### PR DESCRIPTION
The expression "An item(s)" is invalid on grammar when it refers to the plural meaning at which it turns into "An items". To avoid the possibly vague thoughts for some readers about this, change this into "An item or multiple items", towards which readers are able to comprehend both grammatically and misunderstanding-avoidingly.