### PR TITLE
[1.19.x] append the missing border of a table

### DIFF
--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -7,7 +7,7 @@ Example: An event can be used to perform an action when a Vanilla stick is right
 
 The main event bus used for most events is located at `MinecraftForge#EVENT_BUS`. There is another event bus for mod specific events located at `FMLJavaModLoadingContext#getModEventBus` that you should only use in specific cases. More information about this bus can be found below.
 
-Every event is fired on one of these busses: most events are fired on the main forge event bus, but some are fired on the mod specific event buses.
+Every event is fired on one of these buses: most events are fired on the main forge event bus, but some are fired on the mod specific event buses.
 
 An event handler is some method that has been registered to an event bus.
 

--- a/docs/gameeffects/particles.md
+++ b/docs/gameeffects/particles.md
@@ -12,7 +12,7 @@ Particles are broken up between its [**client only**][sides] implementation to d
 | :---             | :---:  |     :---    |
 | ParticleType     | BOTH   | The registry object of a particle's type definition used to reference the particle on either side |
 | ParticleOptions    | BOTH   | A data holder used to sync information from the network or a command to the associated client(s) |
-| ParticleProvider | CLIENT | A factory registered by the `ParticleType` used to construct a `Particle` from the associated `ParticleOptions`.
+| ParticleProvider | CLIENT | A factory registered by the `ParticleType` used to construct a `Particle` from the associated `ParticleOptions`. |
 | Particle         | CLIENT | The renderable logic to display on the associated client(s) |
 
 ### ParticleType


### PR DESCRIPTION
The border of a table within particle.md's contents was missing and consequently readd it.