### PR TITLE
[1.20.x] fix a numeric typo

### DIFF
--- a/docs/concepts/lifecycle.md
+++ b/docs/concepts/lifecycle.md
@@ -30,7 +30,7 @@ public class MyMod {
 Registry Events
 ---------------
 
-The registry events are fired after the mod instance construction. There are two: `NewRegistryEvent`, `DataPackRegistryEvent$NewRegistry` and `RegisterEvent`. These events are fired synchronously during mod loading.
+The registry events are fired after the mod instance construction. There are three: `NewRegistryEvent`, `DataPackRegistryEvent$NewRegistry` and `RegisterEvent`. These events are fired synchronously during mod loading.
 
 `NewRegistryEvent` allows modders to register their own custom registries, using the `RegistryBuilder` class.
 


### PR DESCRIPTION
The count of the events behind the number is three instead of two. Hence turn the figure "two" into "three".