### PR TITLE
1.19.x: correct the typo of an indentation

### DIFF
--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -7,7 +7,7 @@ Example: An event can be used to perform an action when a Vanilla stick is right
 
 The main event bus used for most events is located at `MinecraftForge#EVENT_BUS`. There is another event bus for mod specific events located at `FMLJavaModLoadingContext#getModEventBus` that you should only use in specific cases. More information about this bus can be found below.
 
-Every event is fired on one of these busses: most events are fired on the main forge event bus, but some are fired on the mod specific event buses.
+Every event is fired on one of these buses: most events are fired on the main forge event bus, but some are fired on the mod specific event buses.
 
 An event handler is some method that has been registered to an event bus.
 

--- a/docs/gui/menus.md
+++ b/docs/gui/menus.md
@@ -186,7 +186,7 @@ public ItemStack quickMoveStack(Player player, int quickMovedSlotIndex) {
   // The quick moved slot
   Slot quickMovedSlot = this.slots.get(quickMovedSlotIndex) 
   
-   // If the slot is in the valid range and the slot is not empty
+  // If the slot is in the valid range and the slot is not empty
   if (quickMovedSlot != null && quickMovedSlot.hasItem()) {
     // Get the raw stack to move
     ItemStack rawStack = quickMovedSlot.getItem(); 


### PR DESCRIPTION
Correct the typo of an indentation within menus.md which was not consistent with the Java code.