### PR TITLE
1.19.x: fix a typo

### DIFF
--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -7,7 +7,7 @@ Example: An event can be used to perform an action when a Vanilla stick is right
 
 The main event bus used for most events is located at `MinecraftForge#EVENT_BUS`. There is another event bus for mod specific events located at `FMLJavaModLoadingContext#getModEventBus` that you should only use in specific cases. More information about this bus can be found below.
 
-Every event is fired on one of these busses: most events are fired on the main forge event bus, but some are fired on the mod specific event buses.
+Every event is fired on one of these buses: most events are fired on the main forge event bus, but some are fired on the mod specific event buses.
 
 An event handler is some method that has been registered to an event bus.
 

--- a/docs/gui/screens.md
+++ b/docs/gui/screens.md
@@ -207,7 +207,7 @@ An `AbstractContainerScreen` typically requires three parameters: the container 
 Field             | Description
 :---:             | :---
 `imageWidth`      | The width of the texture used for the background. This is typically inside a PNG of 256 x 256 and defaults to 176.
-`imageHeight`     | The width of the texture used for the background. This is typically inside a PNG of 256 x 256 and defaults to 166.
+`imageHeight`     | The height of the texture used for the background. This is typically inside a PNG of 256 x 256 and defaults to 166.
 `titleLabelX`     | The relative x coordinate of where the screen title will be rendered.
 `titleLabelY`     | The relative y coordinate of where the screen title will be rendered.
 `inventoryLabelX` | The relative x coordinate of where the player inventory name will be rendered.


### PR DESCRIPTION
The "width" here should be the "height" as the field's name is "imageHeight" rather than "imageWidth".