### PR TITLE
1.19.x: Append the missing full point at the end of some sentences

### DIFF
--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -7,7 +7,7 @@ Example: An event can be used to perform an action when a Vanilla stick is right
 
 The main event bus used for most events is located at `MinecraftForge#EVENT_BUS`. There is another event bus for mod specific events located at `FMLJavaModLoadingContext#getModEventBus` that you should only use in specific cases. More information about this bus can be found below.
 
-Every event is fired on one of these busses: most events are fired on the main forge event bus, but some are fired on the mod specific event buses.
+Every event is fired on one of these buses: most events are fired on the main forge event bus, but some are fired on the mod specific event buses.
 
 An event handler is some method that has been registered to an event bus.
 

--- a/docs/datastorage/capabilities.md
+++ b/docs/datastorage/capabilities.md
@@ -10,7 +10,7 @@ Forge adds capability support to BlockEntities, Entities, ItemStacks, Levels, an
 Forge-provided Capabilities
 ---------------------------
 
-Forge provides three capabilities: `IItemHandler`, `IFluidHandler` and `IEnergyStorage`
+Forge provides three capabilities: `IItemHandler`, `IFluidHandler` and `IEnergyStorage`.
 
 `IItemHandler` exposes an interface for handling inventory slots. It can be applied to BlockEntities (chests, machines, etc.), Entities (extra player slots, mob/creature inventories/bags), or ItemStacks (portable backpacks and such). It replaces the old `Container` and `WorldlyContainer` with an automation-friendly system.
 
@@ -23,7 +23,7 @@ Using an Existing Capability
 
 As mentioned earlier, BlockEntities, Entities, and ItemStacks implement the capability provider feature through the `ICapabilityProvider` interface. This interface adds the method `#getCapability`, which can be used to query the capabilities present in the associated provider objects.
 
-In order to obtain a capability, you will need to refer it by its unique instance. In the case of the `IItemHandler`, this capability is primarily stored in `ForgeCapabilities#ITEM_HANDLER`, but it is possible to get other instance references by using `CapabilityManager#get`
+In order to obtain a capability, you will need to refer it by its unique instance. In the case of the `IItemHandler`, this capability is primarily stored in `ForgeCapabilities#ITEM_HANDLER`, but it is possible to get other instance references by using `CapabilityManager#get`.
 
 ```java
 public static final Capability<IItemHandler> ITEM_HANDLER = CapabilityManager.get(new CapabilityToken<>(){});


### PR DESCRIPTION
There were some sentences whose full stops were ignored, consequently add them back.