### PR TITLE
(1.19.x) Update Minecraft Wiki links to new domain

### DIFF
--- a/docs/concepts/internationalization.md
+++ b/docs/concepts/internationalization.md
@@ -63,5 +63,5 @@ A `MutableComponent` can be created using `Component#translatable` by passing in
 
 - `createComponentTranslation(CommandSource, String, Object...)` creates a localized and formatted `MutableComponent` depending on a receiver. The localization and formatting is done eagerly if the receiver is a vanilla client. If not, the localization and formatting is done lazily with a `Component` containing `TranslatableContents`. This is only useful if the server should allow vanilla clients to connect.
 
-[langs]: https://minecraft.fandom.com/wiki/Language#Languages
+[langs]: https://minecraft.wiki/w/Language#Languages
 [converter]: https://tterrag.com/lang2json/

--- a/docs/datagen/client/localization.md
+++ b/docs/datagen/client/localization.md
@@ -36,5 +36,5 @@ this.add("object.examplemod.example_object", "Example Object");
     ```
 
 [lang]: ../../concepts/internationalization.md
-[locale]: https://minecraft.fandom.com/wiki/Language#Languages
+[locale]: https://minecraft.wiki/w/Language#Languages
 [datagen]: ../index.md#data-providers

--- a/docs/datagen/client/modelproviders.md
+++ b/docs/datagen/client/modelproviders.md
@@ -411,7 +411,7 @@ public CompletableFuture<?> run(CachedOutput cache) {
 [color]: ../../resources/client/models/tinting.md#blockcoloritemcolor
 [overrides]: ../../resources/client/models/itemproperties.md
 [blockstateprovider]: #block-state-provider
-[blockstate]: https://minecraft.fandom.com/wiki/Tutorials/Models#Block_states
+[blockstate]: https://minecraft.wiki/w/Tutorials/Models#Block_states
 [blockmodels]: #blockmodelprovider
 [itemmodels]: #itemmodelprovider
 [properties]: ../../blocks/states.md#implementing-block-states

--- a/docs/datagen/index.md
+++ b/docs/datagen/index.md
@@ -65,9 +65,9 @@ The `GatherDataEvent` is fired on the mod event bus when the data generator is b
 * [`advancements.AdvancementProvider`][advgen] - for [advancements]; pass in `AdvancementSubProvider`s to the constructor
 
 [langgen]: ./client/localization.md
-[lang]: https://minecraft.fandom.com/wiki/Language
+[lang]: https://minecraft.wiki/w/Language
 [soundgen]: ./client/sounds.md
-[sounds]: https://minecraft.fandom.com/wiki/Sounds.json
+[sounds]: https://minecraft.wiki/w/Sounds.json
 [modelgen]: ./client/modelproviders.md
 [models]: ../resources/client/models/index.md
 [itemmodelgen]: ./client/modelproviders.md#itemmodelprovider

--- a/docs/gameeffects/sounds.md
+++ b/docs/gameeffects/sounds.md
@@ -104,7 +104,7 @@ Note that each takes a `SoundEvent`, the ones registered above. Additionally, th
     - **Usage**: Just like the ones in `Level`, these two overrides in the player classes seem to be for code that runs together on both sides. The client handles playing the sound to the user, while the server handles everyone else hearing it without re-playing to the original user.
 
 [loc]: ../concepts/resources.md#resourcelocation
-[wiki]: https://minecraft.fandom.com/wiki/Sounds.json
+[wiki]: https://minecraft.wiki/w/Sounds.json
 [datagen]: ../datagen/client/sounds.md
 [registration]: ../concepts/registries.md#methods-for-registering
 [sides]: ../concepts/sides.md

--- a/docs/misc/keymappings.md
+++ b/docs/misc/keymappings.md
@@ -145,7 +145,7 @@ public boolean mouseClicked(double x, double y, int button) {
     If you do not own the screen which you are trying to check a **mouse** for, you can listen to the `Pre` or `Post` events of `ScreenEvent$MouseButtonPressed` on the [**Forge event bus**][forgebus] instead.
 
 [modbus]: ../concepts/events.md#mod-event-bus
-[controls]: https://minecraft.fandom.com/wiki/Options#Controls
+[controls]: https://minecraft.wiki/w/Options#Controls
 [tk]: ../concepts/internationalization.md#translatablecontents
 [keyinput]: https://www.glfw.org/docs/3.3/input_guide.html#input_key
 [forgebus]: ../concepts/events.md#creating-an-event-handler

--- a/docs/rendering/modelextensions/transforms.md
+++ b/docs/rendering/modelextensions/transforms.md
@@ -72,5 +72,5 @@ If the respective rotation is not specified, it will default to no rotation.
 
 The scale must be specified as an array of 3 floating point values representing a three-dimensional vector: `[ x, y, z ]` and defaults to (1, 1, 1) if not present.
 
-[blockstate]: https://minecraft.fandom.com/wiki/Tutorials/Models#Block_states
+[blockstate]: https://minecraft.wiki/w/Tutorials/Models#Block_states
 [displaytransform]: ../modelloaders/transform.md

--- a/docs/resources/client/index.md
+++ b/docs/resources/client/index.md
@@ -10,6 +10,6 @@ You can then follow the steps found [at the Minecraft Wiki][createrespack] to cr
 
 Additional reading: [Resource Locations][resourcelocation]
 
-[respack]: https://minecraft.fandom.com/wiki/Resource_Pack
-[createrespack]: https://minecraft.fandom.com/wiki/Tutorials/Creating_a_resource_pack
+[respack]: https://minecraft.wiki/w/Resource_Pack
+[createrespack]: https://minecraft.wiki/w/Tutorials/Creating_a_resource_pack
 [resourcelocation]: ../../concepts/resources.md#ResourceLocation

--- a/docs/resources/client/models/index.md
+++ b/docs/resources/client/models/index.md
@@ -15,10 +15,10 @@ Models and textures are linked through [`ResourceLocation`][resloc]s but are sto
 
 Textures, like models, are contained within resource packs and are referred to with `ResourceLocation`s. In Minecraft, the [UV coordinates][uv] (0,0) are taken to mean the **top-left** corner. UVs are *always* from 0 to 16. If a texture is larger or smaller, the coordinates are scaled to fit. A texture should also be square, and the side length of a texture should be a power of two, as doing otherwise breaks mipmapping (e.g. 1x1, 2x2, 8x8, 16x16, and 128x128 are good. 5x5 and 30x30 are not recommended because they are not powers of 2. 5x10 and 4x8 are completely broken as they are not square.). Textures should only ever be not a square if it is [animated][animated].
 
-[models]: https://minecraft.fandom.com/wiki/Tutorials/Models#File_path
+[models]: https://minecraft.wiki/w/Tutorials/Models#File_path
 [resloc]: ../../../concepts/resources.md#resourcelocation
-[statemodel]: https://minecraft.fandom.com/wiki/Tutorials/Models#Block_states
-[itemmodels]: https://minecraft.fandom.com/wiki/Tutorials/Models#Item_models
+[statemodel]: https://minecraft.wiki/w/Tutorials/Models#Block_states
+[itemmodels]: https://minecraft.wiki/w/Tutorials/Models#Item_models
 [state]: ../../../blocks/states.md
 [uv]: https://en.wikipedia.org/wiki/UV_mapping
-[animated]: https://minecraft.fandom.com/wiki/Resource_Pack?so=search#Animation
+[animated]: https://minecraft.wiki/w/Resource_Pack?so=search#Animation

--- a/docs/resources/client/models/itemproperties.md
+++ b/docs/resources/client/models/itemproperties.md
@@ -59,4 +59,4 @@ private void setup(final FMLClientSetupEvent event)
 }
 ```
 
-[format]: https://minecraft.fandom.com/wiki/Tutorials/Models#Item_models
+[format]: https://minecraft.wiki/w/Tutorials/Models#Item_models

--- a/docs/resources/client/models/tinting.md
+++ b/docs/resources/client/models/tinting.md
@@ -29,4 +29,4 @@ public void registerItemColors(RegisterColorHandlersEvent.Item event){
 }
 ```
 
-[wiki]: https://minecraft.fandom.com/wiki/Tutorials/Models#Block_models
+[wiki]: https://minecraft.wiki/w/Tutorials/Models#Block_models

--- a/docs/resources/server/advancements.md
+++ b/docs/resources/server/advancements.md
@@ -158,8 +158,8 @@ When an advancement is completed, rewards may be given out. These can be a combi
 }
 ```
 
-[datapack]: https://minecraft.fandom.com/wiki/Data_pack
-[wiki]: https://minecraft.fandom.com/wiki/Advancement/JSON_format
+[datapack]: https://minecraft.wiki/w/Data_pack
+[wiki]: https://minecraft.wiki/w/Advancement/JSON_format
 [conditional]: ./conditional.md#implementations
-[function]: https://minecraft.fandom.com/wiki/Function_(Java_Edition)
-[triggers]: https://minecraft.fandom.com/wiki/Advancement/JSON_format#List_of_triggers
+[function]: https://minecraft.wiki/w/Function_(Java_Edition)
+[triggers]: https://minecraft.wiki/w/Advancement/JSON_format#List_of_triggers

--- a/docs/resources/server/index.md
+++ b/docs/resources/server/index.md
@@ -9,6 +9,6 @@ You can then follow the steps found [here][createdatapack] to create any datapac
 
 Additional reading: [Resource Locations][resourcelocation]
 
-[datapack]: https://minecraft.fandom.com/wiki/Data_pack
-[createdatapack]: https://minecraft.fandom.com/wiki/Tutorials/Creating_a_data_pack
+[datapack]: https://minecraft.wiki/w/Data_pack
+[createdatapack]: https://minecraft.wiki/w/Tutorials/Creating_a_data_pack
 [resourcelocation]: ../../concepts/resources.md#ResourceLocation

--- a/docs/resources/server/loottables.md
+++ b/docs/resources/server/loottables.md
@@ -103,7 +103,7 @@ Forge adds an additional `LootItemCondition` which checks whether the given `Loo
 }
 ```
 
-[datapack]: https://minecraft.fandom.com/wiki/Data_pack
-[wiki]: https://minecraft.fandom.com/wiki/Loot_table
+[datapack]: https://minecraft.wiki/w/Data_pack
+[wiki]: https://minecraft.wiki/w/Loot_table
 [event]: ../../concepts/events.md#creating-an-event-handler
 [glm]: ./glm.md

--- a/docs/resources/server/recipes/custom.md
+++ b/docs/resources/server/recipes/custom.md
@@ -123,6 +123,6 @@ Data Generation
 All custom recipes, regardless of input or output data, can be created into a `FinishedRecipe` for [data generation][datagen] using the `RecipeProvider`.
 
 [forge]: ../../../concepts/registries.md#methods-for-registering
-[json]: https://minecraft.fandom.com/wiki/Recipe#JSON_format
+[json]: https://minecraft.wiki/w/Recipe#JSON_format
 [manager]: ./index.md#recipe-manager
 [datagen]: ../../../datagen/server/recipes.md#custom-recipe-serializers

--- a/docs/resources/server/recipes/index.md
+++ b/docs/resources/server/recipes/index.md
@@ -93,8 +93,8 @@ Larger crafting grids in recipes can be [data generated][datagen].
 
 A few additional [ingredient types][ingredients] are added to allow recipes to have inputs which check tag data or combine multiple ingredients into a single input checker.
 
-[datapack]: https://minecraft.fandom.com/wiki/Data_pack
-[wiki]: https://minecraft.fandom.com/wiki/Recipe
+[datapack]: https://minecraft.wiki/w/Data_pack
+[wiki]: https://minecraft.wiki/w/Recipe
 [advancement]: ../advancements.md
 [datagen]: ../../../datagen/server/recipes.md
 [cap]: ../../../datastorage/capabilities.md

--- a/docs/resources/server/recipes/ingredients.md
+++ b/docs/resources/server/recipes/ingredients.md
@@ -168,7 +168,7 @@ public IIngredientSerializer<? extends Ingredient> getSerializer() {
 !!! tip
     If using `FMLCommonSetupEvent` to register an ingredient serializer, it must be enqueued to the synchronous work queue via `FMLCommonSetupEvent#enqueueWork` as `CraftingHelper#register` is not thread-safe.
 
-[recipes]: https://minecraft.fandom.com/wiki/Recipe#List_of_recipe_types
+[recipes]: https://minecraft.wiki/w/Recipe#List_of_recipe_types
 [nbt]: #strictnbtingredient
 [serializer]: #iingredientserializer
 [compound]: #compoundingredient

--- a/docs/resources/server/tags.md
+++ b/docs/resources/server/tags.md
@@ -113,8 +113,8 @@ Using Tags in Recipes and Advancements
 Tags are directly supported by Vanilla. See the respective Vanilla wiki pages for [recipes] and [advancements] for usage details.
 
 [datapack]: ./index.md
-[tags]: https://minecraft.fandom.com/wiki/Tag#JSON_format
-[taglist]: https://minecraft.fandom.com/wiki/Tag#List_of_tags
+[tags]: https://minecraft.wiki/w/Tag#JSON_format
+[taglist]: https://minecraft.wiki/w/Tag#List_of_tags
 [forgetags]: https://github.com/MinecraftForge/MinecraftForge/tree/1.19.x/src/generated/resources/data/forge/tags
-[recipes]: https://minecraft.fandom.com/wiki/Recipe#JSON_format
-[advancements]: https://minecraft.fandom.com/wiki/Advancement
+[recipes]: https://minecraft.wiki/w/Recipe#JSON_format
+[advancements]: https://minecraft.wiki/w/Advancement


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.