### PR TITLE
Fix mkdocs warnings

### DIFF
--- a/docs/datastorage/codecs.md
+++ b/docs/datastorage/codecs.md
@@ -224,7 +224,7 @@ public static final Codec<Integer> INT_CODEC = Codec.STRING.comapFlatMap(
 Range codecs are an implementation of `#flatXMap` which returns an error `DataResult` if the value is not inclusively between the set minimum and maximum. The value is still provided as a partial result if outside the bounds. There are implementations for integers, floats, and doubles via `#intRange`, `#floatRange`, and `#doubleRange` respectively.
 
 ```java
-public static final Codec<Integer> RANGE_CODEC = Codec.intRange(0, 4); 
+public static final Codec<Integer> RANGE_CODEC = Codec.intRange(0, 4);
 ```
 
 ```js
@@ -431,7 +431,7 @@ public static final Codec<ExampleObject> = DISPATCH.getCodec() // Gets Codec<Cod
 
 [DataFixerUpper]: https://github.com/Mojang/DataFixerUpper
 [gson]: https://github.com/google/gson
-[transformer]: #transformer-codecs
+[transformer]: #transformers
 [pair]: #pair
 [records]: #records
 [field]: #fields

--- a/docs/misc/gametest.md
+++ b/docs/misc/gametest.md
@@ -259,4 +259,4 @@ property 'forge.enableGameTest', 'true'
 [test]: #running-game-tests
 [namespaces]: #enabling-other-namespaces
 [event]: ../concepts/events.md#creating-an-event-handler
-[buildscript]: ../gettingstarted/index.md#simple-buildgradle-customizations
+[buildscript]: ../gettingstarted/index.md#customizing-your-mod-information

--- a/docs/rendering/modelextensions/visibility.md
+++ b/docs/rendering/modelextensions/visibility.md
@@ -1,7 +1,7 @@
 Part Visibility
 ===============
 
-Adding the `visibility` entry at the top level of a model JSON allows control over the visibility of different parts of the model to decide whether they should be baked into the final [`BakedModel`][bakedmodel]. The definition of a "part" is dependent on the model loader loading this model and custom model loaders are free to ignore this entry completely. Out of the model loaders provided by Forge only the [composite model loader][composite] and the [OBJ model loader][obj] make use of this functionality. The visibility entries are specified as `"part name": boolean` entries.
+Adding the `visibility` entry at the top level of a model JSON allows control over the visibility of different parts of the model to decide whether they should be baked into the final [`BakedModel`][bakedmodel]. The definition of a "part" is dependent on the model loader loading this model and custom model loaders are free to ignore this entry completely. Out of the model loaders provided by Forge only the composite model loader and the [OBJ model loader][obj] make use of this functionality. The visibility entries are specified as `"part name": boolean` entries.
 
 Example of a composite model with two parts, the second of which will not be baked into the final model, and two child models overriding this visibility to have only the first part and both parts visible respectively:
 ```js
@@ -48,5 +48,4 @@ This allows setups like the following where multiple models use different parts 
 3. These child models individually specify different visibilities for the parts
 
 [bakedmodel]: ../modelloaders/bakedmodel.md
-[composite]: ../modelloaders/index.md/#composite-models
 [obj]: ../modelloaders/index.md/#wavefront-obj-models

--- a/docs/rendering/modelloaders/bakedmodel.md
+++ b/docs/rendering/modelloaders/bakedmodel.md
@@ -11,7 +11,7 @@ Returns the [`ItemOverrides`][overrides] to use for this model. This is only use
 
 ### `useAmbientOcclusion`
 
-If the model is rendered as a block in the level, the block in question does not emit any light, and ambient occlusion is enabled. This causes the model to be rendered with [ambient occlusion](ambocc).
+If the model is rendered as a block in the level, the block in question does not emit any light, and ambient occlusion is enabled. This causes the model to be rendered with [ambient occlusion][ambocc].
 
 ### `isGui3d`
 
@@ -43,7 +43,7 @@ See [Transform][transform].
 
 This is the main method of `BakedModel`. It returns a list of `BakedQuad`s: objects which contain the low-level vertex data that will be used to render the model. If the model is being rendered as a block, then the `BlockState` passed in is non-null. If the model is being rendered as an item, the `ItemOverrides` returned from `#getOverrides` is responsible for handling the state of the item, and the `BlockState` parameter will be `null`.
 
-!!! note 
+!!! note
     The origin point for the vertices in a `BakedQuad` is the bottom, northwest corner. Vertex coordinate values less than 0 or greater than 1 will position the vertex outside of the block. To avoid lighting issues, provide the vertices in counterclockwise order.
 
 The `Direction` passed in is used for face culling. If the block against the given side of another block being rendered is opaque, then the faces associated with that side are not rendered. If that parameter is `null`, all faces not associated with a side are returned (that will never be culled).

--- a/docs/resources/client/index.md
+++ b/docs/resources/client/index.md
@@ -12,4 +12,4 @@ Additional reading: [Resource Locations][resourcelocation]
 
 [respack]: https://minecraft.wiki/w/Resource_Pack
 [createrespack]: https://minecraft.wiki/w/Tutorials/Creating_a_resource_pack
-[resourcelocation]: ../../concepts/resources.md#ResourceLocation
+[resourcelocation]: ../../concepts/resources.md#resourcelocation

--- a/docs/resources/server/glm.md
+++ b/docs/resources/server/glm.md
@@ -137,7 +137,7 @@ public static final RegistryObject<Codec<ExampleModifier>> = REGISTRAR.register(
 [Examples][examples] can be found on the Forge Git repository, including silk touch and smelting effects.
 
 [tags]: ./tags.md
-[resloc]: ../../concepts/resources.md#ResourceLocation
+[resloc]: ../../concepts/resources.md#resourcelocation
 [codec]: #the-loot-modifier-codec
 [registered]: ../../concepts/registries.md#methods-for-registering
 [codecdef]: ../../datastorage/codecs.md

--- a/docs/resources/server/index.md
+++ b/docs/resources/server/index.md
@@ -11,4 +11,4 @@ Additional reading: [Resource Locations][resourcelocation]
 
 [datapack]: https://minecraft.wiki/w/Data_pack
 [createdatapack]: https://minecraft.wiki/w/Tutorials/Creating_a_data_pack
-[resourcelocation]: ../../concepts/resources.md#ResourceLocation
+[resourcelocation]: ../../concepts/resources.md#resourcelocation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,6 @@ nav:
     - Screens: 'gui/screens.md'
   - Rendering:
     - Model Extensions:
-      - Introduction: 'rendering/modelextensions/index.md'
       - Root Transforms: 'rendering/modelextensions/transforms.md'
       - Render Types: 'rendering/modelextensions/rendertypes.md'
       - Part Visibility: 'rendering/modelextensions/visibility.md'


### PR DESCRIPTION
Omnibus fixup of all the helpful warning output from mkdocs. Running `mkdocs serve` now emits zero warnings about broken links/anchors.